### PR TITLE
[core] Added provider boot concept

### DIFF
--- a/lib/cache/test/setup.ts
+++ b/lib/cache/test/setup.ts
@@ -9,9 +9,12 @@ import { Script } from '@exteranto/support'
 
 chai.use(chaiAsPromised);
 
-new App(Script.BACKGROUND, {
+const app: App = new App(Script.BACKGROUND, {
   providers: [],
   bound: {
     cache: { driver: 'local', timeout: 1 }
   }
-}, {}).bootstrap()
+}, {})
+
+app.start()
+app.boot()

--- a/lib/compatibility/test/setup.ts
+++ b/lib/compatibility/test/setup.ts
@@ -9,4 +9,7 @@ import { Script } from '@exteranto/support'
 
 chai.use(chaiAsPromised);
 
-new App(Script.BACKGROUND, { providers: [] }, {}).bootstrap()
+const app: App = new App(Script.BACKGROUND, { providers: [] }, {})
+
+app.start()
+app.boot()

--- a/lib/core/src/App.ts
+++ b/lib/core/src/App.ts
@@ -12,6 +12,13 @@ export class App {
   private dispatcher: Dispatcher
 
   /**
+   * The provider instances.
+   *
+   * @var {Provider[]} providers
+   */
+  private providers: Provider[]
+
+  /**
    * Class constructor.
    *
    * @param {Script} script
@@ -32,7 +39,12 @@ export class App {
   public bootstrap () : void {
     this.registerBaseParams()
     this.registerParamBindings()
+
+    // Find, boot and register providers.
+    this.findProviders()
+    this.bootProviders()
     this.registerProviders()
+
     this.registerEvents()
     this.fireBootedEvent()
   }
@@ -46,18 +58,26 @@ export class App {
   }
 
   /**
+   * Find and instantiate specified service providers.
+   */
+  private findProviders () : void {
+    this.providers = this.config.providers
+      .map(Constructor => new Constructor(Container))
+      .filter(provider => provider.only().filter(script => script === this.script).length === 1)
+  }
+
+  /**
+   * Boot specified service providers.
+   */
+  private bootProviders () : void {
+    this.providers.forEach(provider => provider.boot())
+  }
+
+  /**
    * Register specified service providers.
    */
   private registerProviders () : void {
-    this.config.providers.forEach((Constructor) => {
-      const provider: Provider = new Constructor
-
-      // Register the provider only if the current script is in the desired
-      // scripts array.
-      if (provider.only().filter(i => i === this.script).length === 1) {
-        provider.register(Container)
-      }
-    })
+    this.providers.forEach(provider => provider.register())
   }
 
   /**

--- a/lib/core/src/App.ts
+++ b/lib/core/src/App.ts
@@ -30,21 +30,23 @@ export class App {
     private config: any,
     private events: any,
   ) {
-    //
   }
 
   /**
-   * Bootstraps the whole application.
+   * Starts the whole application.
    */
-  public bootstrap () : void {
+  public start () : void {
     this.registerBaseParams()
     this.registerParamBindings()
-
-    // Find, boot and register providers.
     this.findProviders()
     this.bootProviders()
-    this.registerProviders()
+  }
 
+  /**
+   * Boots the whole application.
+   */
+  public boot () : void {
+    this.registerProviders()
     this.registerEvents()
     this.fireBootedEvent()
   }
@@ -58,12 +60,21 @@ export class App {
   }
 
   /**
+   * Register specified parameter bindings.
+   */
+  private registerParamBindings () : void {
+    for (const key in this.config.bound || []) {
+      Container.bindParam(key, this.config.bound[key])
+    }
+  }
+
+  /**
    * Find and instantiate specified service providers.
    */
   private findProviders () : void {
     this.providers = this.config.providers
       .map(Constructor => new Constructor(Container))
-      .filter(provider => provider.only().filter(script => script === this.script).length === 1)
+      .filter(provider => provider.only().indexOf(this.script) !== -1)
   }
 
   /**
@@ -78,15 +89,6 @@ export class App {
    */
   private registerProviders () : void {
     this.providers.forEach(provider => provider.register())
-  }
-
-  /**
-   * Register specified parameter bindings.
-   */
-  private registerParamBindings () : void {
-    for (const key in this.config.bound || []) {
-      Container.bindParam(key, this.config.bound[key])
-    }
   }
 
   /**

--- a/lib/core/test/spec/App.spec.ts
+++ b/lib/core/test/spec/App.spec.ts
@@ -12,7 +12,9 @@ describe('App Class', () => {
   })
 
   it('should register base container parameters', () => {
-    new App(Script.BACKGROUND, { providers: [] }, {}).bootstrap()
+    const app: App = new App(Script.BACKGROUND, { providers: [] }, {})
+    app.start()
+    app.boot()
 
     expect(Container.resolveParam('browser')).to.equal(Browser.TESTING)
     expect(Container.resolveParam('script')).to.equal(Script.BACKGROUND)
@@ -20,41 +22,52 @@ describe('App Class', () => {
 
   it('should find providers', () => {
     const app: App = new App(Script.BACKGROUND, { providers: [TestProvider] }, {})
-    app.bootstrap()
+    app.start()
+    app.boot()
 
     expect((app as any).providers).to.have.lengthOf(1)
   })
 
   it('should boot providers', () => {
-    new App(Script.BACKGROUND, { providers: [TestProvider] }, {}).bootstrap()
+    const app: App = new App(Script.BACKGROUND, { providers: [TestProvider] }, {})
+    app.start()
+    app.boot()
 
     expect(Container.resolveParam('test')).to.equal('test')
   })
 
   it('should register providers', () => {
-    new App(Script.BACKGROUND, { providers: [TestProvider] }, {}).bootstrap()
+    const app: App = new App(Script.BACKGROUND, { providers: [TestProvider] }, {})
+    app.start()
+    app.boot()
 
     expect(Container.resolveParam('test2')).to.equal('test2')
   })
 
   it('should register param bindings', () => {
-    new App(Script.BACKGROUND, { providers: [], bound: { param: 'exteranto' } }, {}).bootstrap()
+    const app: App = new App(Script.BACKGROUND, { providers: [], bound: { param: 'exteranto' } }, {})
+    app.start()
+    app.boot()
 
     expect(Container.resolveParam('param')).to.equal('exteranto')
   })
 
   it('should register events', (done) => {
-    new App(Script.BACKGROUND, { providers: [] }, { 'app.test': TestListener }).bootstrap()
+    const app: App = new App(Script.BACKGROUND, { providers: [] }, { 'app.test': TestListener })
+    app.start()
+    app.boot()
 
     dispatcher.fire('app.test', done)
   })
 
   it('should fire the app.booted event', (done) => {
-    new App(Script.BACKGROUND, { providers: [] }, { 'app.booted': class implements Listener {
+    const app: App = new App(Script.BACKGROUND, { providers: [] }, { 'app.booted': class implements Listener {
       handle () : void {
         done()
       }
-    } }).bootstrap()
+    } })
+    app.start()
+    app.boot()
   })
 
 })

--- a/lib/core/test/spec/App.spec.ts
+++ b/lib/core/test/spec/App.spec.ts
@@ -18,10 +18,23 @@ describe('App Class', () => {
     expect(Container.resolveParam('script')).to.equal(Script.BACKGROUND)
   })
 
-  it('should register providers', () => {
+  it('should find providers', () => {
+    const app: App = new App(Script.BACKGROUND, { providers: [TestProvider] }, {})
+    app.bootstrap()
+
+    expect((app as any).providers).to.have.lengthOf(1)
+  })
+
+  it('should boot providers', () => {
     new App(Script.BACKGROUND, { providers: [TestProvider] }, {}).bootstrap()
 
     expect(Container.resolveParam('test')).to.equal('test')
+  })
+
+  it('should register providers', () => {
+    new App(Script.BACKGROUND, { providers: [TestProvider] }, {}).bootstrap()
+
+    expect(Container.resolveParam('test2')).to.equal('test2')
   })
 
   it('should register param bindings', () => {
@@ -48,8 +61,12 @@ describe('App Class', () => {
 
 class TestProvider extends Provider {
 
-  register (container: any) : void {
-    container.bindParam('test', 'test')
+  boot () : void {
+    this.container.bindParam('test', 'test')
+  }
+
+  register () : void {
+    this.container.bindParam('test2', 'test2')
   }
 }
 

--- a/lib/management/src/permissions/PermissionManagerProvider.ts
+++ b/lib/management/src/permissions/PermissionManagerProvider.ts
@@ -6,18 +6,23 @@ import { PermissionManager as SafariPermissionManager } from './safari/Permissio
 
 export class PermissionManagerProvider extends Provider {
   /**
-   * Register the provider services.
-   *
-   * @param {any} container
+   * Boot the provider services.
    */
-  public register (container: any) : void {
-    container.bind(ChromePermissionManager)
+  public boot () : void {
+    this.container.bind(ChromePermissionManager)
       .to(PermissionManager).for(Browser.CHROME)
 
-    container.bind(ExtensionsPermissionManager)
+    this.container.bind(ExtensionsPermissionManager)
       .to(PermissionManager).for(Browser.EXTENSIONS)
 
-    container.bind(SafariPermissionManager)
+    this.container.bind(SafariPermissionManager)
       .to(PermissionManager).for(Browser.SAFARI)
+  }
+
+  /**
+   * Register the provider services.
+   */
+  public register () : void {
+    //
   }
 }

--- a/lib/management/test/setup.ts
+++ b/lib/management/test/setup.ts
@@ -17,9 +17,12 @@ import { PermissionManagerProvider } from '../src'
 
 chai.use(chaiAsPromised)
 
-new App(Script.BACKGROUND, {
+const app: App = new App(Script.BACKGROUND, {
   providers: [PermissionManagerProvider]
-}, {}).bootstrap()
+}, {})
+
+app.start()
+app.boot()
 
 ;(global as any).chrome = chrome
 ;(global as any).browser = browser

--- a/lib/messaging/src/MessagingProvider.ts
+++ b/lib/messaging/src/MessagingProvider.ts
@@ -6,13 +6,18 @@ import { Messaging as SafariMessaging } from './safari/Messaging'
 
 export class MessagingProvider extends Provider {
   /**
-   * Register the provider services.
-   *
-   * @param {any} container
+   * Boot the provider services.
    */
-  public register (container: any) : void {
-    container.bind(ChromeMessaging).to(Messaging).for(Browser.CHROME)
-    container.bind(ExtensionsMessaging).to(Messaging).for(Browser.EXTENSIONS)
-    container.bind(SafariMessaging).to(Messaging).for(Browser.SAFARI)
+  public boot () : void {
+    this.container.bind(ChromeMessaging).to(Messaging).for(Browser.CHROME)
+    this.container.bind(ExtensionsMessaging).to(Messaging).for(Browser.EXTENSIONS)
+    this.container.bind(SafariMessaging).to(Messaging).for(Browser.SAFARI)
+  }
+
+  /**
+   * Register the provider services.
+   */
+  public register () : void {
+    //
   }
 }

--- a/lib/messaging/test/setup.ts
+++ b/lib/messaging/test/setup.ts
@@ -17,13 +17,16 @@ import { MessagingProvider } from '../src/MessagingProvider'
 
 chai.use(chaiAsPromised);
 
-new App(Script.BACKGROUND, {
+const app: App = new App(Script.BACKGROUND, {
   providers: [MessagingProvider],
-}, {}).bootstrap();
+}, {})
 
-(global as any).chrome = chrome;
-(global as any).browser = browser;
-(global as any).safari = safari;
+app.start()
+app.boot()
+
+;(global as any).chrome = chrome;
+;(global as any).browser = browser;
+;(global as any).safari = safari;
 
 beforeEach(() => {
   chrome.flush()

--- a/lib/storage/src/StorageProvider.ts
+++ b/lib/storage/src/StorageProvider.ts
@@ -6,13 +6,18 @@ import { Storage } from './Storage'
 
 export class StorageProvider extends Provider {
   /**
-   * Register the provider services.
-   *
-   * @param {any} container
+   * Boot the provider services.
    */
-  public register (container: any) : void {
-    container.bind(ChromeStorage).to(Storage).for(Browser.CHROME)
-    container.bind(ExtensionsStorage).to(Storage).for(Browser.EXTENSIONS)
-    container.bind(SafariStorage).to(Storage).for(Browser.SAFARI)
+  public boot () : void {
+    this.container.bind(ChromeStorage).to(Storage).for(Browser.CHROME)
+    this.container.bind(ExtensionsStorage).to(Storage).for(Browser.EXTENSIONS)
+    this.container.bind(SafariStorage).to(Storage).for(Browser.SAFARI)
+  }
+
+  /**
+   * Register the provider services.
+   */
+  public register () : void {
+    //
   }
 }

--- a/lib/storage/test/setup.ts
+++ b/lib/storage/test/setup.ts
@@ -17,13 +17,16 @@ import { StorageProvider } from '../src/StorageProvider'
 
 chai.use(chaiAsPromised)
 
-new App(Script.BACKGROUND, {
+const app: App = new App(Script.BACKGROUND, {
   providers: [StorageProvider],
-}, {}).bootstrap();
+}, {})
 
-(global as any).chrome = chrome;
-(global as any).browser = browser;
-(global as any).localStorage = localStorage;
+app.start()
+app.boot()
+
+;(global as any).chrome = chrome;
+;(global as any).browser = browser;
+;(global as any).localStorage = localStorage;
 
 beforeEach(() => {
   chrome.flush()

--- a/lib/support/src/Provider.ts
+++ b/lib/support/src/Provider.ts
@@ -2,6 +2,15 @@ import { Script } from './Script'
 
 export abstract class Provider {
   /**
+   * Class constructor.
+   *
+   * @param {any} container
+   */
+  constructor (protected container: any) {
+    //
+  }
+
+  /**
    * The scripts that this provider should be registered for.
    *
    * @return {Script[]}
@@ -11,9 +20,12 @@ export abstract class Provider {
   }
 
   /**
-   * Register the provider services.
-   *
-   * @param {any} container
+   * Boot the provider services.
    */
-  public abstract register (container: any) : void
+  public abstract boot () : void
+
+  /**
+   * Register the provider services.
+   */
+  public abstract register () : void
 }

--- a/lib/tabs/src/TabsProvider.ts
+++ b/lib/tabs/src/TabsProvider.ts
@@ -16,26 +16,20 @@ export class TabsProvider extends Provider {
   }
 
   /**
-   * Register the provider services.
-   *
-   * @param {any} container
+   * Boot the provider services.
    */
-  public register (container: any) : void {
-    container.bind(ChromeTabs).to(Tabs).for(Browser.CHROME)
-    container.bind(ExtensionsTabs).to(Tabs).for(Browser.EXTENSIONS)
-    container.bind(SafariTabs).to(Tabs).for(Browser.SAFARI)
-
-    container.resolve(Tabs).registerEvents(
-      container.resolve(Dispatcher),
-    )
+  public boot () : void {
+    this.container.bind(ChromeTabs).to(Tabs).for(Browser.CHROME)
+    this.container.bind(ExtensionsTabs).to(Tabs).for(Browser.EXTENSIONS)
+    this.container.bind(SafariTabs).to(Tabs).for(Browser.SAFARI)
   }
 
   /**
-   * Register all native events on the given module.
-   *
-   * @param {Dispatcher} dispatcher
+   * Register the provider services.
    */
-  public registerEvents (dispatcher: Dispatcher) : void {
-    //
+  public register () : void {
+    this.container.resolve(Tabs).registerEvents(
+      this.container.resolve(Dispatcher),
+    )
   }
 }

--- a/lib/tabs/test/setup.ts
+++ b/lib/tabs/test/setup.ts
@@ -20,9 +20,12 @@ chai.use(chaiAsPromised)
 ;(global as any).chrome = chrome
 ;(global as any).browser = browser
 
-new App(Script.BACKGROUND, {
+const app: App = new App(Script.BACKGROUND, {
   providers: [TabsProvider],
-}, {}).bootstrap()
+}, {})
+
+app.start()
+app.boot()
 
 beforeEach(() => {
   chrome.flush()


### PR DESCRIPTION
Added support for `boot` method on each provider which should now serve as a place to register services instead of the `register` method. The `register` method should now register native events and/or publish assets. This improvement closes #7 