### PR TITLE
event now only registered on safari

### DIFF
--- a/lib/api/src/browserAction/safari/BrowserAction.ts
+++ b/lib/api/src/browserAction/safari/BrowserAction.ts
@@ -1,6 +1,6 @@
+import { Dispatcher } from '@exteranto/core'
 import { TabActivatedEvent } from '@internal/tabs'
 import { BrowserActionClickedEvent } from '../events'
-import { Listen, Dispatcher } from '@exteranto/core'
 import { TabIdUnknownException } from '@exteranto/exceptions'
 import { BrowserAction as AbstractBrowserAction } from '../BrowserAction'
 
@@ -102,6 +102,10 @@ export class BrowserAction extends AbstractBrowserAction {
    * @inheritdoc
    */
   public registerEvents (dispatcher: Dispatcher) : void {
+    dispatcher
+      .touch(TabActivatedEvent as any)
+      .addHook((event: TabActivatedEvent) => this.refreshBadge(event.getTabId()))
+
     safari.application.addEventListener('command', ({ command }) => {
       if (command !== 'openOverlay') {
         return
@@ -111,16 +115,6 @@ export class BrowserAction extends AbstractBrowserAction {
         id: safari.application.activeBrowserWindow.activeTab.eid,
       }))
     }, false)
-  }
-
-  /**
-   * Listen for the tab activated event to refresh the badge.
-   *
-   * @param {TabActivatedEvent} event
-   */
-  @Listen(TabActivatedEvent)
-  private refreshBadgeWhenTabActivated (event: TabActivatedEvent) : void {
-    this.refreshBadge(event.getTabId())
   }
 
   /**

--- a/lib/core/src/app/App.ts
+++ b/lib/core/src/app/App.ts
@@ -25,12 +25,12 @@ export class App {
    *
    * @param {Script} script
    * @param {any} config
-   * @param {(touch: (e: typeof Event) => ListenerBag) => void} registerEvents
+   * @param {(touch: (e: new () => Event) => ListenerBag) => void} registerEvents
    */
   constructor (
     private script: Script,
     private config: any,
-    private registerEvents: (touch: (e: typeof Event) => ListenerBag) => void,
+    private registerEvents: (touch: (e: new () => Event) => ListenerBag) => void,
   ) {
     //
   }

--- a/lib/core/src/events/Dispatcher.ts
+++ b/lib/core/src/events/Dispatcher.ts
@@ -15,27 +15,27 @@ export class Dispatcher {
   /**
    * Map of event names to their respective types.
    *
-   * @var {Map<string, typeof Event>} types
+   * @var {Map<string, new () => Event>} types
    */
-  private types: Map<string, typeof Event> = new Map()
+  private types: Map<string, new () => Event> = new Map()
 
   /**
    * Return the type associated with the event name.
    *
    * @param {string} name
-   * @return {typeof Event}
+   * @return {new () => Event}
    */
-  public type (name: string) : typeof Event {
+  public type (name: string) : new () => Event {
     return this.types.get(name)
   }
 
   /**
    * Return the listener bag assigned to the specified event.
    *
-   * @param {typeof Event} event
+   * @param {new () => Event} event
    * @return {ListenerBag}
    */
-  public touch (event: typeof Event) : ListenerBag {
+  public touch (event: new () => Event) : ListenerBag {
     // Add the types to the event map.
     this.types.set(event.name, event)
 
@@ -81,7 +81,7 @@ export class Dispatcher {
       return this.fire(event)
     }
 
-    this.touch(event.constructor as typeof Event).mailbox
+    this.touch(event.constructor as new () => Event).mailbox
       .push(() => this.fire(event))
   }
 }

--- a/lib/core/test/app/spec/App.spec.ts
+++ b/lib/core/test/app/spec/App.spec.ts
@@ -60,7 +60,7 @@ describe('App Class should', () => {
     const app: App = new App(
       Script.BACKGROUND,
       { providers: [] },
-      touch => touch(<typeof Event> TestEvent).addHook((_: TestEvent) => done())
+      touch => touch(TestEvent).addHook((_: TestEvent) => done())
     )
 
     app.start()


### PR DESCRIPTION
**References issue**
#56 

**Describe the pull request**
Fixed the bug where the `@Listen` annotation in Safari APIs was registered on Chrome by replacing it with a dispatcher call in the `registerEvents` method. Also changed the signature of `Dispatcher`'s `touch` to accept `new () => Event` rather than `typeof Event`
