### PR TITLE
Bugfix runtime url

### DIFF
--- a/lib/api/package-lock.json
+++ b/lib/api/package-lock.json
@@ -1,23 +1,23 @@
 {
   "name": "@exteranto/api",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@exteranto/core": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@exteranto/core/-/core-2.1.1.tgz",
-      "integrity": "sha512-9j1fNIbytfCmCSocge7D0C+1JHA4fM8YRvGewTSZ5vUCfo/INQ9t+I7nWmMuZyPu54lksLJQjVcGXW+oWCZhhQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@exteranto/core/-/core-2.1.2.tgz",
+      "integrity": "sha512-D1qNLDrDUAlXOyzjIwSpQ1Hfrz5dkUQxZfXL1B3QDX1FYcWZKdY9PdraZhRmSm6tTls6UXvzQiYYTzG3vtwAIQ==",
       "requires": {
-        "@exteranto/exceptions": "^2.1.1",
+        "@exteranto/exceptions": "^2.1.2",
         "reflect-metadata": "^0.1.12",
         "typescript": "^2.9.2"
       }
     },
     "@exteranto/exceptions": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@exteranto/exceptions/-/exceptions-2.1.1.tgz",
-      "integrity": "sha512-Jx42bDh2nIFPuh4atC+Crn/zuSDYWMoqnN2KtSJvp0zbnn95VXqvszNMIVUYDDhMtrWZ5v4lh6+wbr6p3q/ADA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@exteranto/exceptions/-/exceptions-2.1.2.tgz",
+      "integrity": "sha512-gPzy0GgZNyRKH3+dz6Xw+n7Nc502TlrQdIXdX9lbV/z8gf8eU8e4+ETh+i9VJsuFBbJVb7SV2jMk31AZVEVEhw==",
       "requires": {
         "typescript": "^2.9.2"
       }
@@ -819,13 +819,37 @@
       }
     },
     "ttypescript": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.5.tgz",
-      "integrity": "sha512-ke01qTl2su6pzE9T9b1BgmtAq5kVqXzpiP4x0wiIme0nG+suR+eiZTC4tWA6EKn1mHaH4b86G4QOOhLIxEH9FA==",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.6.tgz",
+      "integrity": "sha512-+JbeQt3W+VJMsnvDMVX2/LojRJqLBQzQWE1hI5ZTR2+9EoWXnQ4fUD+tMWCCda1LY2Z5EtwWWrWYmNziw4CYZA==",
       "dev": true,
       "requires": {
-        "resolve": "^1.7.1",
-        "ts-node": "^6.0.2"
+        "resolve": "^1.9.0",
+        "ts-node": "^7.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "ts-node": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+          "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+          "dev": true,
+          "requires": {
+            "arrify": "^1.0.0",
+            "buffer-from": "^1.1.0",
+            "diff": "^3.1.0",
+            "make-error": "^1.1.1",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "source-map-support": "^0.5.6",
+            "yn": "^2.0.0"
+          }
+        }
       }
     },
     "type-detect": {

--- a/lib/api/package.json
+++ b/lib/api/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@exteranto/api",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "The collection of API Drivers for the Exteranto Framework.",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
   "scripts": {
     "build": "tslint --config ../../tslint.json --project tsconfig.json && ttsc",
-    "test": "for d in test/*/; do mocha -b ${d}/setup.ts ${d}/**/*.spec.ts -r ts-node/register -r tsconfig-paths/register || exit 1; done"
+    "test": "for d in test/*/; do mocha ${d}/setup.ts ${d}/**/*.spec.ts -r ts-node/register -r tsconfig-paths/register || exit 1; done"
   },
   "keywords": [
     "extension",
@@ -31,8 +31,8 @@
   "repository": "github:exteranto/api",
   "license": "MIT",
   "dependencies": {
-    "@exteranto/core": "^2.1.1",
-    "@exteranto/exceptions": "^2.1.1",
+    "@exteranto/core": "^2.1.2",
+    "@exteranto/exceptions": "^2.1.2",
     "@types/chrome": "0.0.65",
     "typescript": "^2.9.1",
     "web-ext-types": "^2.1.0"
@@ -53,6 +53,6 @@
     "ts-node": "^6.1.0",
     "tsconfig-paths": "^3.7.0",
     "tslint": "^5.11.0",
-    "ttypescript": "^1.5.5"
+    "ttypescript": "^1.5.6"
   }
 }

--- a/lib/api/src/browserAction/safari/BrowserAction.ts
+++ b/lib/api/src/browserAction/safari/BrowserAction.ts
@@ -4,8 +4,6 @@ import { BrowserActionClickedEvent } from '../events'
 import { TabIdUnknownException } from '@exteranto/exceptions'
 import { BrowserAction as AbstractBrowserAction } from '../BrowserAction'
 
-declare var safari: any
-
 export class BrowserAction extends AbstractBrowserAction {
   /**
    * @inheritdoc

--- a/lib/api/src/extension/Extension.ts
+++ b/lib/api/src/extension/Extension.ts
@@ -1,0 +1,12 @@
+
+export abstract class Extension {
+
+  /**
+   * Converts a relative path within extension file tree to a URL.
+   *
+   * @param {string} path
+   * @return {string}
+   */
+  // TODO: Make sure the url points to the same directory in all browsers.
+  public abstract getUrl (path?: string) : string
+}

--- a/lib/api/src/extension/ExtensionProvider.ts
+++ b/lib/api/src/extension/ExtensionProvider.ts
@@ -1,0 +1,25 @@
+import { Browser, Provider } from '@exteranto/core'
+
+import { Extension } from './Extension'
+import { Extension as ChromeExtension } from './chrome/Extension'
+import { Extension as SafariExtension } from './safari/Extension'
+import { Extension as ExtensionsExtension } from './extensions/Extension'
+
+export class ExtensionProvider extends Provider {
+
+  /**
+   * Boot the provider services.
+   */
+  public boot () : void {
+    this.container.bind(ChromeExtension).to(Extension).for(Browser.CHROME)
+    this.container.bind(ExtensionsExtension).to(Extension).for(Browser.EXTENSIONS)
+    this.container.bind(SafariExtension).to(Extension).for(Browser.SAFARI)
+  }
+
+  /**
+   * Register the provider services.
+   */
+  public register () : void {
+    //
+  }
+}

--- a/lib/api/src/extension/chrome/Extension.ts
+++ b/lib/api/src/extension/chrome/Extension.ts
@@ -1,0 +1,11 @@
+import { Extension as AbstractExtension } from '../Extension'
+
+export class Extension extends AbstractExtension {
+
+  /**
+   * @inheritdoc
+   */
+  public getUrl (path: string = '') : string {
+    return chrome.runtime.getURL(path)
+  }
+}

--- a/lib/api/src/extension/extensions/Extension.ts
+++ b/lib/api/src/extension/extensions/Extension.ts
@@ -1,0 +1,11 @@
+import { Extension as AbstractExtension } from '../Extension'
+
+export class Extension extends AbstractExtension {
+
+  /**
+   * @inheritdoc
+   */
+  public getUrl (path: string = '') : string {
+    return browser.runtime.getURL(path)
+  }
+}

--- a/lib/api/src/extension/index.ts
+++ b/lib/api/src/extension/index.ts
@@ -1,0 +1,2 @@
+export { Extension } from './Extension'
+export { ExtensionProvider } from './ExtensionProvider'

--- a/lib/api/src/extension/safari/Extension.ts
+++ b/lib/api/src/extension/safari/Extension.ts
@@ -1,0 +1,11 @@
+import { Extension as AbstractExtension } from '../Extension'
+
+export class Extension extends AbstractExtension {
+
+  /**
+   * @inheritdoc
+   */
+  public getUrl (path: string = '') : string {
+    return `${safari.extension.baseURI}${path}`
+  }
+}

--- a/lib/api/src/index.ts
+++ b/lib/api/src/index.ts
@@ -1,5 +1,6 @@
 export * from './browserAction'
 export * from './cookies'
+export * from './extension'
 export * from './messaging'
 export * from './permissions'
 export * from './runtime'

--- a/lib/api/src/messaging/safari/Messaging.ts
+++ b/lib/api/src/messaging/safari/Messaging.ts
@@ -1,8 +1,6 @@
 import { Message } from '../Message'
 import { Messaging as AbstractMessaging } from '../Messaging'
 
-declare var safari: any
-
 export class Messaging extends AbstractMessaging {
   /**
    * The object that contains promises to be resolved upon receiving a response.

--- a/lib/api/src/runtime/Runtime.ts
+++ b/lib/api/src/runtime/Runtime.ts
@@ -11,14 +11,6 @@ export abstract class Runtime implements RegistersNativeEvents {
   public abstract setUninstallUrl (url: string) : Promise<void>
 
   /**
-   * Converts a relative path within extension file tree to a URL.
-   *
-   * @param {string} path
-   */
-  // TODO: Make sure the url points to the same directory in all browsers.
-  public abstract extensionUrl (path?: string) : string
-
-  /**
    * Register all native events on the given module.
    *
    * @param {Dispatcher} dispatcher

--- a/lib/api/src/runtime/RuntimeProvider.ts
+++ b/lib/api/src/runtime/RuntimeProvider.ts
@@ -9,6 +9,15 @@ import { Runtime as ExtensionsRuntime } from './extensions/Runtime'
 export class RuntimeProvider extends Provider {
 
   /**
+   * The scripts that this provider should be registered for.
+   *
+   * @return {Script[]}
+   */
+  public only () : Script[] {
+    return [Script.BACKGROUND]
+  }
+
+  /**
    * Boot the provider services.
    */
   public boot () : void {

--- a/lib/api/src/runtime/chrome/Runtime.ts
+++ b/lib/api/src/runtime/chrome/Runtime.ts
@@ -22,13 +22,6 @@ export class Runtime extends AbstractRuntime {
   /**
    * @inheritdoc
    */
-  public extensionUrl (path: string = '') : string {
-    return chrome.runtime.getURL(path)
-  }
-
-  /**
-   * @inheritdoc
-   */
   public registerEvents (dispatcher: Dispatcher) : void {
     register(dispatcher)
   }

--- a/lib/api/src/runtime/extensions/Runtime.ts
+++ b/lib/api/src/runtime/extensions/Runtime.ts
@@ -15,13 +15,6 @@ export class Runtime extends AbstractRuntime {
   /**
    * @inheritdoc
    */
-  public extensionUrl (path: string = '') : string {
-    return browser.runtime.getURL(path)
-  }
-
-  /**
-   * @inheritdoc
-   */
   public registerEvents (dispatcher: Dispatcher) : void {
     register(dispatcher)
   }

--- a/lib/api/src/runtime/safari/Runtime.ts
+++ b/lib/api/src/runtime/safari/Runtime.ts
@@ -3,21 +3,12 @@ import { Dispatcher } from '@exteranto/core'
 import { Runtime as AbstractRuntime } from '../Runtime'
 import { NotImplementedException } from '@exteranto/exceptions'
 
-declare var safari: any
-
 export class Runtime extends AbstractRuntime {
   /**
    * @inheritdoc
    */
   public async setUninstallUrl (_: string) : Promise<void> {
     throw new NotImplementedException()
-  }
-
-  /**
-   * @inheritdoc
-   */
-  public extensionUrl (path: string = '') : string {
-    return `${safari.extension.baseURI}${path}`
   }
 
   /**

--- a/lib/api/src/runtime/safari/events.ts
+++ b/lib/api/src/runtime/safari/events.ts
@@ -7,8 +7,6 @@ import {
   ExtensionInstalledEvent,
 } from '../events'
 
-declare var safari: any
-
 export const register: (dispatcher: Dispatcher) => void = (dispatcher) => {
   safari.application.addEventListener('beforeNavigate', (event) => {
     dispatcher.fire(new WebRequestBeforeRedirectedEvent({

--- a/lib/api/src/safari.d.ts
+++ b/lib/api/src/safari.d.ts
@@ -1,0 +1,1 @@
+declare var safari: any

--- a/lib/api/src/tabs/safari/Tabs.ts
+++ b/lib/api/src/tabs/safari/Tabs.ts
@@ -5,8 +5,6 @@ import { Tabs as AbstractTabs } from '../Tabs'
 import { Dispatcher, RegistersNativeEvents } from '@exteranto/core'
 import { TabIdUnknownException } from '@exteranto/exceptions'
 
-declare var safari: any
-
 export class Tabs extends AbstractTabs implements RegistersNativeEvents {
 
   /**

--- a/lib/api/src/tabs/safari/events.ts
+++ b/lib/api/src/tabs/safari/events.ts
@@ -8,8 +8,6 @@ import {
   TabRemovedEvent,
 } from '../events'
 
-declare var safari: any
-
 /**
  * Checks whether target is a tab or window.
  *

--- a/lib/api/test/extension/setup.ts
+++ b/lib/api/test/extension/setup.ts
@@ -1,0 +1,32 @@
+/// <reference types="mocha" />
+/// <reference types="chai" />
+/// <reference types="sinon" />
+/// <reference types="sinon-chrome" />
+/// <reference types="node" />
+
+import * as chrome from 'sinon-chrome'
+import { safari } from '../../test/mocks/safari'
+import * as browser from 'sinon-chrome/extensions'
+import { App, Script } from '@exteranto/core'
+import { ExtensionProvider } from '../../src'
+
+;(global as any).chrome = chrome
+;(global as any).browser = browser
+;(global as any).safari = safari
+
+;(global as any).window = {
+  addEventListener: (_, l) => l()
+}
+
+const app: App = new App(Script.BACKGROUND, {
+  providers: [ExtensionProvider]
+}, () => {})
+
+
+app.start()
+app.boot()
+
+beforeEach(() => {
+  chrome.flush()
+  browser.flush()
+})

--- a/lib/api/test/extension/spec/ChromeExtension.spec.ts
+++ b/lib/api/test/extension/spec/ChromeExtension.spec.ts
@@ -14,13 +14,11 @@ export const tests = () => {
     })
 
     it('converts relative path to url', () => {
-      chrome.extension.getURL.returns('chrome://extension/abc/path')
-
-      console.log(chrome.extension.getURL())
+      chrome.runtime.getURL.returns('chrome://extension/abc/path')
 
       expect(extension.getUrl('path'))
         .to.equal('chrome://extension/abc/path')
-      expect(chrome.extension.getURL.calledOnce).to.be.true
+      expect(chrome.runtime.getURL.calledOnce).to.be.true
     })
   })
 }

--- a/lib/api/test/extension/spec/ChromeExtension.spec.ts
+++ b/lib/api/test/extension/spec/ChromeExtension.spec.ts
@@ -1,0 +1,26 @@
+import { expect } from 'chai'
+import * as chrome from 'sinon-chrome'
+import { Extension } from '../../../src'
+import { Browser, Container } from '@exteranto/core'
+
+export const tests = () => {
+  describe('Chrome', () => {
+    let extension: Extension
+
+    before(() => {
+      Container.bindParam('browser', Browser.CHROME)
+
+      extension = Container.resolve(Extension)
+    })
+
+    it('converts relative path to url', () => {
+      chrome.extension.getURL.returns('chrome://extension/abc/path')
+
+      console.log(chrome.extension.getURL())
+
+      expect(extension.getUrl('path'))
+        .to.equal('chrome://extension/abc/path')
+      expect(chrome.extension.getURL.calledOnce).to.be.true
+    })
+  })
+}

--- a/lib/api/test/extension/spec/Extension.spec.ts
+++ b/lib/api/test/extension/spec/Extension.spec.ts
@@ -1,0 +1,11 @@
+import { tests as ChromeTests } from './ChromeExtension.spec'
+import { tests as SafariTests } from './SafariExtension.spec'
+import { tests as ExtensionsTests } from './ExtensionsExtension.spec'
+
+describe('Extension', () => {
+  SafariTests()
+
+  ChromeTests()
+
+  ExtensionsTests()
+})

--- a/lib/api/test/extension/spec/ExtensionsExtension.spec.ts
+++ b/lib/api/test/extension/spec/ExtensionsExtension.spec.ts
@@ -1,0 +1,26 @@
+import { expect } from 'chai'
+import * as browser from 'sinon-chrome/extensions'
+import { Container, Browser } from '@exteranto/core'
+import { Extension } from '../../../src'
+
+declare var global: any
+
+export const tests = () => {
+  describe('Extensions', () => {
+    let extension: Extension
+
+    before(() => {
+      Container.bindParam('browser', Browser.EXTENSIONS)
+
+      extension = Container.resolve(Extension)
+    })
+
+    it('converts relative path to url', () => {
+      browser.extension.getURL.returns('extensions://extension/abc/path')
+
+      expect(extension.getUrl('path'))
+        .to.equal('extensions://extension/abc/path')
+      expect(browser.extension.getURL.calledOnce).to.be.true
+    })
+  })
+}

--- a/lib/api/test/extension/spec/ExtensionsExtension.spec.ts
+++ b/lib/api/test/extension/spec/ExtensionsExtension.spec.ts
@@ -16,11 +16,11 @@ export const tests = () => {
     })
 
     it('converts relative path to url', () => {
-      browser.extension.getURL.returns('extensions://extension/abc/path')
+      browser.runtime.getURL.returns('extensions://extension/abc/path')
 
       expect(extension.getUrl('path'))
         .to.equal('extensions://extension/abc/path')
-      expect(browser.extension.getURL.calledOnce).to.be.true
+      expect(browser.runtime.getURL.calledOnce).to.be.true
     })
   })
 }

--- a/lib/api/test/extension/spec/SafariExtension.spec.ts
+++ b/lib/api/test/extension/spec/SafariExtension.spec.ts
@@ -1,0 +1,22 @@
+import { expect } from 'chai'
+import { Container, Browser } from '@exteranto/core'
+import { Extension } from '../../../src'
+
+declare var global: any
+
+export const tests = () => {
+  describe('Safari', () => {
+    let extension: Extension
+
+    before(() => {
+      Container.bindParam('browser', Browser.SAFARI)
+
+      extension = Container.resolve(Extension)
+    })
+
+    it('converts relative path to url', () => {
+      expect(extension.getUrl('path'))
+        .to.equal('safari-extension://abc/path')
+    })
+  })
+}

--- a/lib/api/test/runtime/spec/ChromeRuntime.spec.ts
+++ b/lib/api/test/runtime/spec/ChromeRuntime.spec.ts
@@ -47,14 +47,6 @@ export const tests = () => {
         .to.eventually.be.rejectedWith(InvalidUrlFormatException)
     })
 
-    it('converts relative path to url', async () => {
-      chrome.runtime.getURL.returns('chrome://extension/abc/path')
-
-      expect(runtime.extensionUrl('path'))
-        .to.equal('chrome://extension/abc/path')
-      expect(chrome.runtime.getURL.calledOnce).to.be.true
-    })
-
     it('registers install event', (done) => {
       global.app.boot()
 

--- a/lib/api/test/runtime/spec/ExtensionsRuntime.spec.ts
+++ b/lib/api/test/runtime/spec/ExtensionsRuntime.spec.ts
@@ -48,14 +48,6 @@ export const tests = () => {
       sinon.assert.calledOnce(browser.runtime.setUninstallURL)
     })
 
-    it('converts relative path to url', async () => {
-      browser.runtime.getURL.returns('browser://extension/abc/path')
-
-      expect(runtime.extensionUrl('path'))
-        .to.equal('browser://extension/abc/path')
-      expect(browser.runtime.getURL.calledOnce).to.be.true
-    })
-
     it('registers install event', (done) => {
       global.app.boot()
 

--- a/lib/api/test/runtime/spec/SafariRuntime.spec.ts
+++ b/lib/api/test/runtime/spec/SafariRuntime.spec.ts
@@ -36,11 +36,6 @@ export const tests = () => {
         .to.eventually.be.rejectedWith(NotImplementedException)
     })
 
-    it('converts relative path to url', async () => {
-      expect(runtime.extensionUrl('path'))
-        .to.equal('safari-extension://abc/path')
-    })
-
     it('registers install event', (done) => {
       global.app.boot()
 

--- a/lib/core/package-lock.json
+++ b/lib/core/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@exteranto/core",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@exteranto/exceptions": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@exteranto/exceptions/-/exceptions-2.1.1.tgz",
-      "integrity": "sha512-Jx42bDh2nIFPuh4atC+Crn/zuSDYWMoqnN2KtSJvp0zbnn95VXqvszNMIVUYDDhMtrWZ5v4lh6+wbr6p3q/ADA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@exteranto/exceptions/-/exceptions-2.1.2.tgz",
+      "integrity": "sha512-gPzy0GgZNyRKH3+dz6Xw+n7Nc502TlrQdIXdX9lbV/z8gf8eU8e4+ETh+i9VJsuFBbJVb7SV2jMk31AZVEVEhw==",
       "requires": {
         "typescript": "^2.9.2"
       }
@@ -740,13 +740,37 @@
       }
     },
     "ttypescript": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.5.tgz",
-      "integrity": "sha512-ke01qTl2su6pzE9T9b1BgmtAq5kVqXzpiP4x0wiIme0nG+suR+eiZTC4tWA6EKn1mHaH4b86G4QOOhLIxEH9FA==",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.6.tgz",
+      "integrity": "sha512-+JbeQt3W+VJMsnvDMVX2/LojRJqLBQzQWE1hI5ZTR2+9EoWXnQ4fUD+tMWCCda1LY2Z5EtwWWrWYmNziw4CYZA==",
       "dev": true,
       "requires": {
-        "resolve": "^1.7.1",
-        "ts-node": "^6.0.2"
+        "resolve": "^1.9.0",
+        "ts-node": "^7.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "ts-node": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+          "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+          "dev": true,
+          "requires": {
+            "arrify": "^1.0.0",
+            "buffer-from": "^1.1.0",
+            "diff": "^3.1.0",
+            "make-error": "^1.1.1",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "source-map-support": "^0.5.6",
+            "yn": "^2.0.0"
+          }
+        }
       }
     },
     "type-detect": {

--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exteranto/core",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "The Application Core Functionality for the Exteranto Framework.",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -30,7 +30,7 @@
   "repository": "github:exteranto/core",
   "license": "MIT",
   "dependencies": {
-    "@exteranto/exceptions": "^2.1.1",
+    "@exteranto/exceptions": "^2.1.2",
     "reflect-metadata": "^0.1.12",
     "typescript": "^2.9.2"
   },
@@ -47,6 +47,6 @@
     "ts-node": "^6.2.0",
     "tsconfig-paths": "^3.7.0",
     "tslint": "^5.11.0",
-    "ttypescript": "^1.5.5"
+    "ttypescript": "^1.5.6"
   }
 }

--- a/lib/exceptions/package-lock.json
+++ b/lib/exceptions/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@exteranto/exceptions",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/lib/exceptions/package.json
+++ b/lib/exceptions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exteranto/exceptions",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "The Exceptions Package for the Exteranto Framework.",
   "main": "dist/index.js",
   "types": "types/index.d.ts",

--- a/lib/utils/package-lock.json
+++ b/lib/utils/package-lock.json
@@ -1,35 +1,35 @@
 {
   "name": "@exteranto/utils",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@exteranto/api": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@exteranto/api/-/api-2.1.1.tgz",
-      "integrity": "sha512-diXdOBgtJZY/EgrXC3A4wb6sk1+jz8Bd/pe+0PZbloR0+tDsh3vaBirQpM/S/vDJRxJDc0fvgdJxcwQ2sE9feg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@exteranto/api/-/api-2.1.2.tgz",
+      "integrity": "sha512-OrYWlHQBaLXic9PoVC0OTvuNF/AEo+xpLwMKTq7c+KAb+vvIqaAvUAGC+C+pkYdPmr5flwhetyw8cvr1aH5k4w==",
       "requires": {
-        "@exteranto/core": "^2.1.1",
-        "@exteranto/exceptions": "^2.1.1",
+        "@exteranto/core": "^2.1.2",
+        "@exteranto/exceptions": "^2.1.2",
         "@types/chrome": "0.0.65",
         "typescript": "^2.9.1",
         "web-ext-types": "^2.1.0"
       }
     },
     "@exteranto/core": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@exteranto/core/-/core-2.1.1.tgz",
-      "integrity": "sha512-9j1fNIbytfCmCSocge7D0C+1JHA4fM8YRvGewTSZ5vUCfo/INQ9t+I7nWmMuZyPu54lksLJQjVcGXW+oWCZhhQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@exteranto/core/-/core-2.1.2.tgz",
+      "integrity": "sha512-D1qNLDrDUAlXOyzjIwSpQ1Hfrz5dkUQxZfXL1B3QDX1FYcWZKdY9PdraZhRmSm6tTls6UXvzQiYYTzG3vtwAIQ==",
       "requires": {
-        "@exteranto/exceptions": "^2.1.1",
+        "@exteranto/exceptions": "^2.1.2",
         "reflect-metadata": "^0.1.12",
         "typescript": "^2.9.2"
       }
     },
     "@exteranto/exceptions": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@exteranto/exceptions/-/exceptions-2.1.1.tgz",
-      "integrity": "sha512-Jx42bDh2nIFPuh4atC+Crn/zuSDYWMoqnN2KtSJvp0zbnn95VXqvszNMIVUYDDhMtrWZ5v4lh6+wbr6p3q/ADA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@exteranto/exceptions/-/exceptions-2.1.2.tgz",
+      "integrity": "sha512-gPzy0GgZNyRKH3+dz6Xw+n7Nc502TlrQdIXdX9lbV/z8gf8eU8e4+ETh+i9VJsuFBbJVb7SV2jMk31AZVEVEhw==",
       "requires": {
         "typescript": "^2.9.2"
       }
@@ -788,13 +788,37 @@
       }
     },
     "ttypescript": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.5.tgz",
-      "integrity": "sha512-ke01qTl2su6pzE9T9b1BgmtAq5kVqXzpiP4x0wiIme0nG+suR+eiZTC4tWA6EKn1mHaH4b86G4QOOhLIxEH9FA==",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.6.tgz",
+      "integrity": "sha512-+JbeQt3W+VJMsnvDMVX2/LojRJqLBQzQWE1hI5ZTR2+9EoWXnQ4fUD+tMWCCda1LY2Z5EtwWWrWYmNziw4CYZA==",
       "dev": true,
       "requires": {
-        "resolve": "^1.7.1",
-        "ts-node": "^6.0.2"
+        "resolve": "^1.9.0",
+        "ts-node": "^7.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "ts-node": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+          "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+          "dev": true,
+          "requires": {
+            "arrify": "^1.0.0",
+            "buffer-from": "^1.1.0",
+            "diff": "^3.1.0",
+            "make-error": "^1.1.1",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "source-map-support": "^0.5.6",
+            "yn": "^2.0.0"
+          }
+        }
       }
     },
     "type-detect": {

--- a/lib/utils/package.json
+++ b/lib/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exteranto/utils",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "The Utils for the Exteranto Framework.",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -30,9 +30,9 @@
   "repository": "github:exteranto/utils",
   "license": "MIT",
   "dependencies": {
-    "@exteranto/api": "^2.1.1",
-    "@exteranto/core": "^2.1.1",
-    "@exteranto/exceptions": "^2.1.1",
+    "@exteranto/api": "^2.1.2",
+    "@exteranto/core": "^2.1.2",
+    "@exteranto/exceptions": "^2.1.2",
     "md5-typescript": "^1.0.5",
     "typescript": "^2.9.2"
   },
@@ -49,6 +49,6 @@
     "ts-node": "^6.2.0",
     "tsconfig-paths": "^3.7.0",
     "tslint": "^5.11.0",
-    "ttypescript": "^1.5.5"
+    "ttypescript": "^1.5.6"
   }
 }


### PR DESCRIPTION
**References issue**
#61 

**Describe the pull request**
This separates the `chrome.runtime.getURL` api from the rest of runtime as it can be used in the content script.

**New features or API**
```typescript
import { Extension } from '@exteranto/api'

// ...

this.extension.getUrl('static/logo.png') 
```