### PR TITLE
fixed key bug and registered messaging for content only

### DIFF
--- a/lib/api/src/messaging/MessagingProvider.ts
+++ b/lib/api/src/messaging/MessagingProvider.ts
@@ -1,4 +1,4 @@
-import { Browser, Provider } from '@exteranto/core'
+import { Browser, Provider, Script } from '@exteranto/core'
 
 import { Messaging } from './Messaging'
 import { Messaging as ChromeMessaging } from './chrome/Messaging'
@@ -6,6 +6,15 @@ import { Messaging as ExtensionsMessaging } from './extensions/Messaging'
 import { Messaging as SafariMessaging } from './safari/Messaging'
 
 export class MessagingProvider extends Provider {
+
+  /**
+   * The scripts that this provider should be registered for.
+   *
+   * @return Array of Script enums that this provider should be registered for
+   */
+  public only () : Script[] {
+    return [Script.CONTENT]
+  }
 
   /**
    * Boot the provider services.

--- a/lib/api/src/messaging/chrome/Messaging.ts
+++ b/lib/api/src/messaging/chrome/Messaging.ts
@@ -38,7 +38,7 @@ export class Messaging extends AbstractMessaging {
 
       port.postMessage({
         event: message.constructor.name,
-        request: message.payload,
+        payload: message.payload,
       })
 
       // This is triggered upon receiving a response from the listener.

--- a/lib/api/src/messaging/extensions/Messaging.ts
+++ b/lib/api/src/messaging/extensions/Messaging.ts
@@ -38,7 +38,7 @@ export class Messaging extends AbstractMessaging {
 
       port.postMessage({
         event: message.constructor.name,
-        request: message.payload,
+        payload: message.payload,
       })
 
       // This is triggered upon receiving a response from the listener.

--- a/lib/api/test/spec/messaging/chrome.ts
+++ b/lib/api/test/spec/messaging/chrome.ts
@@ -19,7 +19,14 @@ export default ({ chrome }) => {
 
   it('sends a message via runtime port', async () => {
     chrome.runtime.connect.returns({
-      postMessage: m => m,
+      postMessage: (message) => {
+        expect(message).to.deep.equal({
+          event: 'TestMessage',
+          payload: 'test'
+        })
+
+        return message
+      },
       onMessage: { addListener: l => l({ ok: true, body: 'resolved' }) }
     })
 

--- a/lib/api/test/spec/messaging/extensions.ts
+++ b/lib/api/test/spec/messaging/extensions.ts
@@ -19,7 +19,14 @@ export default ({ browser }) => {
 
   it('sends a message via runtime port', async () => {
     browser.runtime.connect.returns({
-      postMessage: m => m,
+      postMessage: (message) => {
+        expect(message).to.deep.equal({
+          event: 'TestMessage',
+          payload: 'test'
+        })
+
+        return message
+      },
       onMessage: { addListener: l => l({ ok: true, body: 'resolved' }) }
     })
 


### PR DESCRIPTION
**References issue**
#84 #83 

**Describe the pull request**
Fixed bug where messaging was passing the payload under an incorrect key and also registered the messaging provider only for the content script.