### PR TITLE
Bug active tab returns undefined if not set

### DIFF
--- a/lib/api/src/tabs/Tabs.ts
+++ b/lib/api/src/tabs/Tabs.ts
@@ -1,4 +1,5 @@
 import { TabInterface } from './TabInterface'
+import { NoActiveTabException } from './exceptions'
 import { Dispatcher, RegistersNativeEvents } from '@exteranto/core'
 
 export abstract class Tabs implements RegistersNativeEvents {
@@ -7,10 +8,16 @@ export abstract class Tabs implements RegistersNativeEvents {
    * Returns the active tab instance.
    *
    * @return Tab instance
+   * @throws {NoActiveTabException}
    */
   public async active () : Promise<TabInterface> {
-    return this.query({ active: true, currentWindow: true })
-      .then(tabs => tabs.pop())
+    const tabs: TabInterface[] = await this.query({ active: true, currentWindow: true })
+
+    if (tabs.length === 0) {
+      throw new NoActiveTabException()
+    }
+
+    return tabs.pop()
   }
 
   /**

--- a/lib/api/src/tabs/exceptions.ts
+++ b/lib/api/src/tabs/exceptions.ts
@@ -7,3 +7,7 @@ export class TabsException extends Exception {
 export class TabIdUnknownException extends TabsException {
   //
 }
+
+export class NoActiveTabException extends TabsException {
+  //
+}

--- a/lib/api/test/spec/tabs/chrome.ts
+++ b/lib/api/test/spec/tabs/chrome.ts
@@ -36,6 +36,12 @@ export default ({ chrome }) => {
     sinon.assert.calledOnce(chrome.tabs.create)
   })
 
+  it('returns the active tab', async () => {
+    chrome.tabs.query.yields([{ id: 1 }])
+
+    expect(tabs.active()).to.eventually.haveOwnProperty('id').that.is.equal(1)
+  })
+
   it('closes a tab', async () => {
     chrome.tabs.remove.yields(undefined)
 

--- a/lib/api/test/spec/tabs/chrome.ts
+++ b/lib/api/test/spec/tabs/chrome.ts
@@ -43,7 +43,7 @@ export default ({ chrome }) => {
     const active: Promise<TabInterface> = tabs.active()
 
     await expect(active).to.eventually.be.instanceOf(Tab)
-    expect((await active).id()).to.equal(1)
+    expect(active.then(tab => tab.id())).to.eventually.equal(1)
   })
 
   it('throws an exception if no active tab found', async () => {

--- a/lib/api/test/spec/tabs/extensions.ts
+++ b/lib/api/test/spec/tabs/extensions.ts
@@ -8,12 +8,13 @@ import {
   TabUpdatedEvent,
   TabActivatedEvent,
   TabRemovedEvent,
+  TabInterface,
 } from '@internal/tabs'
 
 import { Dispatcher } from '@exteranto/core'
 import { Tab } from '@internal/tabs/extensions/Tab'
-import { TabIdUnknownException } from '@internal/tabs/exceptions'
 import { Tabs as ExtensionsTabs } from '@internal/tabs/extensions/Tabs'
+import { TabIdUnknownException, NoActiveTabException } from '@internal/tabs/exceptions'
 
 export default ({ browser }) => {
   let tabs: Tabs
@@ -34,6 +35,23 @@ export default ({ browser }) => {
 
     sinon.assert.calledOnce(browser.tabs.get)
     sinon.assert.calledOnce(browser.tabs.create)
+  })
+
+  it('returns the active tab', async () => {
+    browser.tabs.query.resolves([{ id: 1 }])
+
+    const active: Promise<TabInterface> = tabs.active()
+
+    await expect(active).to.eventually.be.instanceOf(Tab)
+    expect((await active).id()).to.equal(1)
+  })
+
+  it('throws an exception if no active tab found', async () => {
+    browser.tabs.query.resolves([])
+
+    const active: Promise<TabInterface> = tabs.active()
+
+    await expect(active).to.eventually.be.rejectedWith(NoActiveTabException)
   })
 
   it('closes a tab', async () => {

--- a/lib/api/test/spec/tabs/extensions.ts
+++ b/lib/api/test/spec/tabs/extensions.ts
@@ -43,7 +43,7 @@ export default ({ browser }) => {
     const active: Promise<TabInterface> = tabs.active()
 
     await expect(active).to.eventually.be.instanceOf(Tab)
-    expect((await active).id()).to.equal(1)
+    expect(active.then(tab => tab.id())).to.eventually.equal(1)
   })
 
   it('throws an exception if no active tab found', async () => {

--- a/lib/utils/src/cache/Cache.ts
+++ b/lib/utils/src/cache/Cache.ts
@@ -1,6 +1,6 @@
 import { Md5 } from 'md5-typescript'
 import { Storage } from '@exteranto/api'
-import { Binding, Param, With } from '@exteranto/core'
+import { Binding, Param, Tagged } from '@exteranto/core'
 
 @Binding
 export class Cache {
@@ -8,7 +8,7 @@ export class Cache {
   /**
    * The cache driver to be used.
    */
-  @With<Storage>(['%cache.driver%'])
+  @Tagged<Storage>({ type: '%cache.driver%' })
   private driver: Storage
 
   /**

--- a/lib/utils/test/spec/cache/Cache.spec.ts
+++ b/lib/utils/test/spec/cache/Cache.spec.ts
@@ -92,7 +92,7 @@ describe('Cache', () => {
 })
 
 class StorageImplementation extends Storage {
-  async get () {}
+  async get<T> () { return {} as T}
   async set () {}
   async all () {}
   async remove () {}


### PR DESCRIPTION
**References issue**
#104

**Describe the pull request**
Checks for returned array length before popping. If the length is 0, throws an exception. Also adds tests for both scenarios (tab found and tab nonexistent).
