### PR TITLE
Feature tab favicon api

### DIFF
--- a/lib/api/src/tabs/TabInterface.ts
+++ b/lib/api/src/tabs/TabInterface.ts
@@ -64,6 +64,15 @@ export interface TabInterface {
   unpin () : Promise<TabInterface>
 
   /**
+   * Returns favicon url.
+   *
+   * @return Favicon url path of a tab
+   * @throws {TabIdUnknownException}
+   * @throws {TabHasNoFaviconException}
+   */
+  favicon () : Promise<string>
+
+  /**
    * Sends a message to the tab.
    *
    * @param message Message with payload

--- a/lib/api/src/tabs/TabInterface.ts
+++ b/lib/api/src/tabs/TabInterface.ts
@@ -73,6 +73,14 @@ export interface TabInterface {
   favicon () : Promise<string>
 
   /**
+   * Returns the webpage title.
+   *
+   * @return Title of the webpage
+   * @throws {TabIdUnknownException}
+   */
+  title () : Promise<string>
+
+  /**
    * Sends a message to the tab.
    *
    * @param message Message with payload

--- a/lib/api/src/tabs/chrome/Tab.ts
+++ b/lib/api/src/tabs/chrome/Tab.ts
@@ -123,6 +123,13 @@ export class Tab implements TabInterface {
   /**
    * {@inheritdoc}
    */
+  public async title () : Promise<string> {
+    return this.info().then((tab) => tab.title)
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public send (message: Message) : Promise<any> {
     const port: Port = chrome.tabs.connect(this.tab.id)
 

--- a/lib/api/src/tabs/chrome/Tab.ts
+++ b/lib/api/src/tabs/chrome/Tab.ts
@@ -1,6 +1,6 @@
 import { Message } from '@internal/messaging'
 import { TabInterface } from '../TabInterface'
-import { TabIdUnknownException } from '@internal/tabs/exceptions'
+import { TabIdUnknownException, TabHasNoFaviconException } from '@internal/tabs/exceptions'
 
 import Port = chrome.runtime.Port
 
@@ -23,14 +23,8 @@ export class Tab implements TabInterface {
   /**
    * {@inheritdoc}
    */
-  public url () : Promise<string> {
-    return new Promise((resolve, reject) => {
-      chrome.tabs.get(this.tab.id, (tab) => {
-        chrome.runtime.lastError
-          ? reject(new TabIdUnknownException())
-          : resolve(tab.url)
-      })
-    })
+  public async url () : Promise<string> {
+    return this.info().then(tab => tab.url)
   }
 
   /**
@@ -116,6 +110,19 @@ export class Tab implements TabInterface {
   /**
    * {@inheritdoc}
    */
+  public async favicon () : Promise<string> {
+    return this.info().then((tab) => {
+      if (!tab.favIconUrl) {
+        throw new TabHasNoFaviconException()
+      }
+
+      return tab.favIconUrl
+    })
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public send (message: Message) : Promise<any> {
     const port: Port = chrome.tabs.connect(this.tab.id)
 
@@ -137,6 +144,22 @@ export class Tab implements TabInterface {
    */
   public raw (key: string) : any {
     return this.tab[key]
+  }
+
+  /**
+   * Calls the chrome tab APIs to get information about current tab.
+   *
+   * @return Resolves with chrome tab data object
+   * @throws {TabIdUnknownException}
+   */
+  private info () : Promise<chrome.tabs.Tab> {
+    return new Promise((resolve, reject) => {
+      chrome.tabs.get(this.tab.id, (tab) => {
+        chrome.runtime.lastError
+          ? reject(new TabIdUnknownException())
+          : resolve(tab)
+      })
+    })
   }
 
 }

--- a/lib/api/src/tabs/exceptions.ts
+++ b/lib/api/src/tabs/exceptions.ts
@@ -11,3 +11,7 @@ export class TabIdUnknownException extends TabsException {
 export class NoActiveTabException extends TabsException {
   //
 }
+
+export class TabHasNoFaviconException extends TabsException {
+  //
+}

--- a/lib/api/src/tabs/extensions/Tab.ts
+++ b/lib/api/src/tabs/extensions/Tab.ts
@@ -96,6 +96,13 @@ export class Tab implements TabInterface {
   /**
    * {@inheritdoc}
    */
+  public async title () : Promise<string> {
+    return this.info().then((tab) => tab.title)
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public async send (message: Message) : Promise<any> {
     const port: Port = browser.tabs.connect(this.tab.id)
 

--- a/lib/api/src/tabs/safari/Tab.ts
+++ b/lib/api/src/tabs/safari/Tab.ts
@@ -116,6 +116,13 @@ export class Tab implements TabInterface {
   /**
    * {@inheritdoc}
    */
+  public async title () : Promise<string> {
+    return this.tab.title
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public async send (message: Message) : Promise<any>  {
     const { resolvable, id }: any = ResponseHub
 

--- a/lib/api/src/tabs/safari/Tab.ts
+++ b/lib/api/src/tabs/safari/Tab.ts
@@ -3,7 +3,7 @@ import { Autowired } from '@exteranto/core'
 import { ResponseHub } from './ResponseHub'
 import { Message } from '@internal/messaging'
 import { TabInterface } from '../TabInterface'
-import { TabIdUnknownException } from '../exceptions'
+import { TabIdUnknownException, TabHasNoFaviconException } from '../exceptions'
 
 export class Tab implements TabInterface {
 
@@ -104,6 +104,13 @@ export class Tab implements TabInterface {
    */
   public async unpin () : Promise<TabInterface> {
     return this.pin()
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public async favicon () : Promise<string> {
+    throw new TabHasNoFaviconException()
   }
 
   /**

--- a/lib/api/test/spec/tabs/chrome.ts
+++ b/lib/api/test/spec/tabs/chrome.ts
@@ -115,6 +115,12 @@ export default ({ chrome }) => {
       .to.eventually.equal(2)
   })
 
+  it('resolves with a title', async () => {
+    chrome.tabs.get.yields({ title: 'test' })
+
+    await expect(new Tab({}).title()).to.eventually.equal('test')
+  })
+
   it('resolves with a favicon', async () => {
     chrome.tabs.get.yields({ favIconUrl: 'test' })
 

--- a/lib/api/test/spec/tabs/chrome.ts
+++ b/lib/api/test/spec/tabs/chrome.ts
@@ -14,7 +14,7 @@ import {
 import { Dispatcher } from '@exteranto/core'
 import { Tab } from '@internal/tabs/chrome/Tab'
 import { Tabs as ChromeTabs } from '@internal/tabs/chrome/Tabs'
-import { TabIdUnknownException, NoActiveTabException } from '@internal/tabs/exceptions'
+import { TabIdUnknownException, NoActiveTabException, TabHasNoFaviconException } from '@internal/tabs/exceptions'
 
 export default ({ chrome }) => {
   let tabs: Tabs
@@ -63,7 +63,7 @@ export default ({ chrome }) => {
     sinon.assert.calledOnce(chrome.tabs.remove)
   })
 
-  it('reloads the tab', async () => {
+  it('reloads a tab', async () => {
     chrome.tabs.reload.yields(undefined)
 
     await expect(new Tab({ id: 1 }).reload().then(tab => (tab as any).tab.id))
@@ -72,7 +72,7 @@ export default ({ chrome }) => {
     sinon.assert.calledOnce(chrome.tabs.reload)
   })
 
-  it('duplicates the tab', async () => {
+  it('duplicates a tab', async () => {
     chrome.tabs.duplicate.yields({ id: 2 })
 
     await expect(new Tab({ id: 1 }).duplicate().then(tab => (tab as any).tab.id))
@@ -113,6 +113,19 @@ export default ({ chrome }) => {
 
     await expect(tabs.get(2).then(t => t.id()))
       .to.eventually.equal(2)
+  })
+
+  it('resolves with a favicon', async () => {
+    chrome.tabs.get.yields({ favIconUrl: 'test' })
+
+    await expect(new Tab({}).favicon()).to.eventually.equal('test')
+  })
+
+  it('throws an exception if tab hasn\'t a favicon', async () => {
+    chrome.tabs.get.yields({})
+
+    await expect(new Tab({}).favicon())
+      .to.eventually.be.rejectedWith(TabHasNoFaviconException)
   })
 
   it('throws an exception if tab does not exist', async () => {

--- a/lib/api/test/spec/tabs/extensions.ts
+++ b/lib/api/test/spec/tabs/extensions.ts
@@ -116,6 +116,12 @@ export default ({ browser }) => {
       .to.eventually.equal(2)
   })
 
+  it('resolves with a title', async () => {
+    browser.tabs.get.resolves({ title: 'test' })
+
+    await expect(new Tab({}).favicon()).to.eventually.equal('test')
+  })
+
   it('resolves with a favicon', async () => {
     browser.tabs.get.resolves({ favIconUrl: 'test' })
 

--- a/lib/api/test/spec/tabs/extensions.ts
+++ b/lib/api/test/spec/tabs/extensions.ts
@@ -117,9 +117,8 @@ export default ({ browser }) => {
   })
 
   it('resolves with a title', async () => {
-    browser.tabs.get.resolves({ title: 'test' })
-
-    await expect(new Tab({}).favicon()).to.eventually.equal('test')
+    await expect(new Tab({ title: 'test' }).title())
+      .to.eventually.equal('test')
   })
 
   it('resolves with a favicon', async () => {

--- a/lib/api/test/spec/tabs/extensions.ts
+++ b/lib/api/test/spec/tabs/extensions.ts
@@ -14,7 +14,7 @@ import {
 import { Dispatcher } from '@exteranto/core'
 import { Tab } from '@internal/tabs/extensions/Tab'
 import { Tabs as ExtensionsTabs } from '@internal/tabs/extensions/Tabs'
-import { TabIdUnknownException, NoActiveTabException } from '@internal/tabs/exceptions'
+import { TabIdUnknownException, NoActiveTabException, TabHasNoFaviconException } from '@internal/tabs/exceptions'
 
 export default ({ browser }) => {
 
@@ -114,6 +114,19 @@ export default ({ browser }) => {
 
     await expect(tabs.get(2).then(t => t.id()))
       .to.eventually.equal(2)
+  })
+
+  it('resolves with a favicon', async () => {
+    browser.tabs.get.resolves({ favIconUrl: 'test' })
+
+    await expect(new Tab({}).favicon()).to.eventually.equal('test')
+  })
+
+  it('throws an exception if tab hasn\'t a favicon', async () => {
+    browser.tabs.get.resolves({})
+
+    await expect(new Tab({}).favicon())
+      .to.eventually.be.rejectedWith(TabHasNoFaviconException)
   })
 
   it('throws an exception if tab does not exist', async () => {

--- a/lib/api/test/spec/tabs/extensions.ts
+++ b/lib/api/test/spec/tabs/extensions.ts
@@ -117,7 +117,9 @@ export default ({ browser }) => {
   })
 
   it('resolves with a title', async () => {
-    await expect(new Tab({ title: 'test' }).title())
+    browser.tabs.get.resolves({ title: 'test' })
+
+    await expect(new Tab({}).title())
       .to.eventually.equal('test')
   })
 

--- a/lib/api/test/spec/tabs/safari.ts
+++ b/lib/api/test/spec/tabs/safari.ts
@@ -14,7 +14,7 @@ import {
 import { Dispatcher } from '@exteranto/core'
 import { Tab } from '@internal/tabs/safari/Tab'
 import { Tabs as SafariTabs } from '@internal/tabs/safari/Tabs'
-import { TabIdUnknownException, NoActiveTabException } from '@internal/tabs/exceptions'
+import { TabIdUnknownException, NoActiveTabException, TabHasNoFaviconException } from '@internal/tabs/exceptions'
 
 export default ({ safari }) => {
   let tabs: Tabs
@@ -111,6 +111,11 @@ export default ({ safari }) => {
 
     await expect(tabs.get(123).then(t => t.id()))
       .to.eventually.equal(123)
+  })
+
+  it('throws an exception if favicon method is called', async () => {
+    await expect(new Tab({}).favicon())
+      .to.eventually.be.rejectedWith(TabHasNoFaviconException)
   })
 
   it('throws an exception if tab does not exist', async () => {

--- a/lib/api/test/spec/tabs/safari.ts
+++ b/lib/api/test/spec/tabs/safari.ts
@@ -113,6 +113,12 @@ export default ({ safari }) => {
       .to.eventually.equal(123)
   })
 
+  it('resolves with a title', async () => {
+
+    await expect(new Tab({ title: 'test' }).title())
+      .to.eventually.equal('test')
+  })
+
   it('throws an exception if favicon method is called', async () => {
     await expect(new Tab({}).favicon())
       .to.eventually.be.rejectedWith(TabHasNoFaviconException)


### PR DESCRIPTION
**References issue**
#95 

**Describe the pull request**
Adds `favicon` method for each tab that returns a URL of tab's favicon image.

**Additional context**
On Safari, since there's no favicon information, this method always throws.
