### PR TITLE
Checks for Firefox browser

### DIFF
--- a/lib/core/src/support/Utils.ts
+++ b/lib/core/src/support/Utils.ts
@@ -12,7 +12,7 @@ export class Utils {
       return Browser.TESTING
     }
 
-    return (window as any).chrome === undefined ? (window as any).safari === undefined
+    return (window as any).browser !== undefined ? (window as any).safari === undefined
       ? Browser.EXTENSIONS
       : Browser.SAFARI
       : Browser.CHROME

--- a/lib/core/src/support/Utils.ts
+++ b/lib/core/src/support/Utils.ts
@@ -12,10 +12,9 @@ export class Utils {
       return Browser.TESTING
     }
 
-    return (window as any).browser !== undefined ? (window as any).safari === undefined
-      ? Browser.EXTENSIONS
+    return (window as any).browser !== undefined ? Browser.EXTENSIONS
+      : (window as any).safari === undefined ? Browser.CHROME
       : Browser.SAFARI
-      : Browser.CHROME
   }
 
 }

--- a/lib/core/test/spec/support/Utils.spec.ts
+++ b/lib/core/test/spec/support/Utils.spec.ts
@@ -9,7 +9,7 @@ describe('Utility Class', () => {
   })
 
   it('determines extensions', () => {
-    (global as any).window = { }
+    (global as any).window = { browser: {} }
 
     expect(Utils.currentBrowser()).to.equal(Browser.EXTENSIONS)
   })


### PR DESCRIPTION
**Describe the pull request**
Loads the API for correct browser. `window.chrome` object is set in Firefox whereas `window.browser` is not set in chrome.
