### PR TITLE
Feature tab updated info

### DIFF
--- a/lib/api/src/runtime/safari/events.ts
+++ b/lib/api/src/runtime/safari/events.ts
@@ -1,7 +1,6 @@
 import { Container } from '@exteranto/core'
 import { Dispatcher, Event } from '@exteranto/core'
 import {
-  WebRequestBeforeRedirectedEvent,
   WebRequestCompletedEvent,
   ExtensionUpdatedEvent,
   ExtensionInstalledEvent,
@@ -10,15 +9,6 @@ import {
 declare var safari: any
 
 export const register: (dispatcher: Dispatcher) => void = (dispatcher) => {
-  safari.application.addEventListener('beforeNavigate', (event) => {
-    dispatcher.fire(new WebRequestBeforeRedirectedEvent({
-      redirectUrl: event.url,
-      tabId: event.target.eid,
-      timeStamp: event.timeStamp,
-      url: event.target.url,
-    }))
-  })
-
   safari.application.addEventListener('navigate', (event) => {
     dispatcher.fire(new WebRequestCompletedEvent({
       tabId: event.target.eid,

--- a/lib/api/src/runtime/safari/events.ts
+++ b/lib/api/src/runtime/safari/events.ts
@@ -1,31 +1,16 @@
 import { Container } from '@exteranto/core'
 import { Dispatcher, Event } from '@exteranto/core'
 import {
-  WebRequestCompletedEvent,
   ExtensionUpdatedEvent,
   ExtensionInstalledEvent,
 } from '../events'
-
-declare var safari: any
-
-export const register: (dispatcher: Dispatcher) => void = (dispatcher) => {
-  safari.application.addEventListener('navigate', (event) => {
-    dispatcher.fire(new WebRequestCompletedEvent({
-      tabId: event.target.eid,
-      timeStamp: event.timeStamp,
-      url: event.target.url,
-    }))
-  })
-
-  registerInstallAndUpdateEvents(dispatcher)
-}
 
 /**
  * Registers safari mocks of install and update events.
  *
  * @param dispatcher The dispatched implementation
  */
-const registerInstallAndUpdateEvents: (dispatcher: Dispatcher) => void = (dispatcher) => {
+export const register: (dispatcher: Dispatcher) => void = (dispatcher) => {
   const exteranto: any = getExterantoInfo()
   const previousVersion: string = exteranto.version
   const version: string = Container.getInstance().resolveParam<string>('app.version')

--- a/lib/api/src/tabs/TabChangeInfo.ts
+++ b/lib/api/src/tabs/TabChangeInfo.ts
@@ -1,0 +1,38 @@
+
+export interface TabChangeInfo {
+
+  /**
+   * The status of the tab. Can be either loading or complete.
+   */
+  status?: 'loading' | 'complete'
+
+  /**
+   * The tab's new pinned state.
+   * @since Chrome 9.
+   */
+  pinned?: boolean
+
+  /**
+   * The tab's URL if it has changed.
+   */
+  url?: string
+
+  /**
+   * The tab's new audible state.
+   * @since Chrome 45.
+   */
+  audible?: boolean
+
+  /**
+   * The tab's new favicon URL.
+   * @since Chrome 27.
+   */
+  favIconUrl?: string
+
+  /**
+   * The tab's new title.
+   * @since Chrome 48.
+   */
+  title?: string
+
+}

--- a/lib/api/src/tabs/chrome/events.ts
+++ b/lib/api/src/tabs/chrome/events.ts
@@ -11,8 +11,15 @@ export const register: (dispatcher: Dispatcher) => void = (dispatcher) => {
     dispatcher.fire(new TabCreatedEvent(tab.id))
   })
 
-  chrome.tabs.onUpdated.addListener((_, __, tab) => {
-    dispatcher.fire(new TabUpdatedEvent(tab.id))
+  chrome.tabs.onUpdated.addListener((_, info, tab) => {
+    const status: 'loading' | 'complete' = info.status as 'loading' | 'complete'
+
+    dispatcher.fire(new TabUpdatedEvent(tab.id, {
+      pinned: info.pinned,
+      status,
+      title: info.title,
+      url: info.url,
+    }))
   })
 
   chrome.tabs.onActivated.addListener(({ tabId }) => {

--- a/lib/api/src/tabs/chrome/events.ts
+++ b/lib/api/src/tabs/chrome/events.ts
@@ -1,4 +1,5 @@
 import { Dispatcher } from '@exteranto/core'
+import { TabChangeInfo } from '../TabChangeInfo'
 import {
   TabCreatedEvent,
   TabUpdatedEvent,
@@ -12,7 +13,7 @@ export const register: (dispatcher: Dispatcher) => void = (dispatcher) => {
   })
 
   chrome.tabs.onUpdated.addListener((_, info, tab) => {
-    dispatcher.fire(new TabUpdatedEvent(tab.id, info))
+    dispatcher.fire(new TabUpdatedEvent(tab.id, info as TabChangeInfo))
   })
 
   chrome.tabs.onActivated.addListener(({ tabId }) => {

--- a/lib/api/src/tabs/chrome/events.ts
+++ b/lib/api/src/tabs/chrome/events.ts
@@ -12,14 +12,7 @@ export const register: (dispatcher: Dispatcher) => void = (dispatcher) => {
   })
 
   chrome.tabs.onUpdated.addListener((_, info, tab) => {
-    const status: 'loading' | 'complete' = info.status as 'loading' | 'complete'
-
-    dispatcher.fire(new TabUpdatedEvent(tab.id, {
-      pinned: info.pinned,
-      status,
-      title: info.title,
-      url: info.url,
-    }))
+    dispatcher.fire(new TabUpdatedEvent(tab.id, info))
   })
 
   chrome.tabs.onActivated.addListener(({ tabId }) => {

--- a/lib/api/src/tabs/events.ts
+++ b/lib/api/src/tabs/events.ts
@@ -1,29 +1,5 @@
 import { Event } from '@exteranto/core'
 
-export interface ChangeInfo {
-
-  /**
-   * The loading status of the tab.
-   */
-  status?: 'loading' | 'complete'
-
-  /**
-   * The tab's new URL if it has changed.
-   */
-  url?: string
-
-  /**
-   * The tab's new title if it has changed.
-   */
-  title?: string
-
-  /**
-   * The tab's new pinned status if it has changed.
-   */
-  pinned?: boolean
-
-}
-
 /**
  * Parent event for all tab events.
  */
@@ -54,7 +30,7 @@ export class TabUpdatedEvent extends TabEvent {
   /**
    * @param tabId Id of tab that was activated
    */
-  constructor (tabId: number, public changeInfo: ChangeInfo) {
+  constructor (tabId: number, public changeInfo: chrome.tabs.TabChangeInfo) {
     super(tabId)
   }
 

--- a/lib/api/src/tabs/events.ts
+++ b/lib/api/src/tabs/events.ts
@@ -1,5 +1,29 @@
 import { Event } from '@exteranto/core'
 
+export interface ChangeInfo {
+
+  /**
+   * The loading status of the tab.
+   */
+  status?: 'loading' | 'complete'
+
+  /**
+   * The tab's new URL if it has changed.
+   */
+  url?: string
+
+  /**
+   * The tab's new title if it has changed.
+   */
+  title?: string
+
+  /**
+   * The tab's new pinned status if it has changed.
+   */
+  pinned?: boolean
+
+}
+
 /**
  * Parent event for all tab events.
  */
@@ -26,7 +50,14 @@ export class TabCreatedEvent extends TabEvent {
  * most common is loading new url.
  */
 export class TabUpdatedEvent extends TabEvent {
-  //
+
+  /**
+   * @param tabId Id of tab that was activated
+   */
+  constructor (tabId: number, public changeInfo: ChangeInfo) {
+    super(tabId)
+  }
+
 }
 
 /**

--- a/lib/api/src/tabs/events.ts
+++ b/lib/api/src/tabs/events.ts
@@ -1,4 +1,5 @@
 import { Event } from '@exteranto/core'
+import { TabChangeInfo } from './TabChangeInfo'
 
 /**
  * Parent event for all tab events.
@@ -30,7 +31,7 @@ export class TabUpdatedEvent extends TabEvent {
   /**
    * @param tabId Id of tab that was activated
    */
-  constructor (tabId: number, public changeInfo: chrome.tabs.TabChangeInfo) {
+  constructor (tabId: number, public changeInfo: TabChangeInfo) {
     super(tabId)
   }
 

--- a/lib/api/src/tabs/extensions/events.ts
+++ b/lib/api/src/tabs/extensions/events.ts
@@ -1,4 +1,5 @@
 import { Dispatcher } from '@exteranto/core'
+import { TabChangeInfo } from '../TabChangeInfo'
 import {
   TabCreatedEvent,
   TabUpdatedEvent,
@@ -12,7 +13,7 @@ export const register: (dispatcher: Dispatcher) => void = (dispatcher) => {
   })
 
   browser.tabs.onUpdated.addListener((_, info, tab) => {
-    dispatcher.fire(new TabUpdatedEvent(tab.id, info))
+    dispatcher.fire(new TabUpdatedEvent(tab.id, info as TabChangeInfo))
   })
 
   browser.tabs.onActivated.addListener(({ tabId }) => {

--- a/lib/api/src/tabs/extensions/events.ts
+++ b/lib/api/src/tabs/extensions/events.ts
@@ -11,8 +11,15 @@ export const register: (dispatcher: Dispatcher) => void = (dispatcher) => {
     dispatcher.fire(new TabCreatedEvent(tab.id))
   })
 
-  browser.tabs.onUpdated.addListener((_, __, tab) => {
-    dispatcher.fire(new TabUpdatedEvent(tab.id))
+  browser.tabs.onUpdated.addListener((_, info, tab) => {
+    const status: 'loading' | 'complete' = info.status as 'loading' | 'complete'
+
+    dispatcher.fire(new TabUpdatedEvent(tab.id, {
+      pinned: info.pinned,
+      status,
+      title: info.title,
+      url: info.url,
+    }))
   })
 
   browser.tabs.onActivated.addListener(({ tabId }) => {

--- a/lib/api/src/tabs/extensions/events.ts
+++ b/lib/api/src/tabs/extensions/events.ts
@@ -12,14 +12,7 @@ export const register: (dispatcher: Dispatcher) => void = (dispatcher) => {
   })
 
   browser.tabs.onUpdated.addListener((_, info, tab) => {
-    const status: 'loading' | 'complete' = info.status as 'loading' | 'complete'
-
-    dispatcher.fire(new TabUpdatedEvent(tab.id, {
-      pinned: info.pinned,
-      status,
-      title: info.title,
-      url: info.url,
-    }))
+    dispatcher.fire(new TabUpdatedEvent(tab.id, info))
   })
 
   browser.tabs.onActivated.addListener(({ tabId }) => {

--- a/lib/api/src/tabs/index.ts
+++ b/lib/api/src/tabs/index.ts
@@ -6,6 +6,7 @@
 export { Tabs } from './Tabs'
 export { TabInterface } from './TabInterface'
 export { TabsProvider } from './TabsProvider'
+export { TabChangeInfo } from './TabChangeInfo'
 
 /**
  * Export package events.

--- a/lib/api/src/tabs/safari/events.ts
+++ b/lib/api/src/tabs/safari/events.ts
@@ -91,7 +91,17 @@ const introduceToEcosystem: (target: any, dispatcher: Dispatcher) => void = (tar
   dispatcher.fire(new TabCreatedEvent(target.eid))
 
   target.addEventListener('navigate', () => {
-    dispatcher.fire(new TabUpdatedEvent(target.eid))
+    dispatcher.fire(new TabUpdatedEvent(target.eid, { status: 'complete' }))
+  }, true)
+
+  target.addEventListener('beforeNavigate', (event) => {
+    // Whether the tab url has been changed.
+    const isUrlNew: boolean = event.url !== event.target.url
+
+    dispatcher.fire(new TabUpdatedEvent(target.eid, {
+      status: 'loading',
+      url: isUrlNew ? event.url : undefined,
+    }))
   }, true)
 
   target.addEventListener('close', () => {

--- a/lib/api/test/spec/tabs/chrome.ts
+++ b/lib/api/test/spec/tabs/chrome.ts
@@ -153,9 +153,14 @@ export default ({ chrome }) => {
   it('registers tab updated event', () => {
     tabs.registerEvents(instance(dispatcher))
 
-    chrome.tabs.onUpdated.trigger(1, 2, { id: 2 })
+    chrome.tabs.onUpdated.trigger(1, { status: 'loading' }, { id: 2 })
 
-    verify(dispatcher.fire(deepEqual(new TabUpdatedEvent(2))))
+    verify(dispatcher.fire(deepEqual(new TabUpdatedEvent(2, {
+      status: 'loading',
+      url: undefined,
+      title: undefined,
+      pinned: undefined,
+    }))))
       .once()
   })
 

--- a/lib/api/test/spec/tabs/chrome.ts
+++ b/lib/api/test/spec/tabs/chrome.ts
@@ -157,11 +157,7 @@ export default ({ chrome }) => {
 
     verify(dispatcher.fire(deepEqual(new TabUpdatedEvent(2, {
       status: 'loading',
-      url: undefined,
-      title: undefined,
-      pinned: undefined,
-    }))))
-      .once()
+    })))).once()
   })
 
   it('registers tab activated event', () => {

--- a/lib/api/test/spec/tabs/extensions.ts
+++ b/lib/api/test/spec/tabs/extensions.ts
@@ -158,11 +158,7 @@ export default ({ browser }) => {
 
     verify(dispatcher.fire(deepEqual(new TabUpdatedEvent(2, {
       status: 'loading',
-      url: undefined,
-      title: undefined,
-      pinned: undefined,
-    }))))
-      .once()
+    })))).once()
   })
 
   it('registers tab activated event', () => {

--- a/lib/api/test/spec/tabs/extensions.ts
+++ b/lib/api/test/spec/tabs/extensions.ts
@@ -154,9 +154,14 @@ export default ({ browser }) => {
   it('registers tab updated event', () => {
     tabs.registerEvents(instance(dispatcher))
 
-    browser.tabs.onUpdated.trigger(1, 2, { id: 2 })
+    browser.tabs.onUpdated.trigger(1, { status: 'loading' }, { id: 2 })
 
-    verify(dispatcher.fire(deepEqual(new TabUpdatedEvent(2))))
+    verify(dispatcher.fire(deepEqual(new TabUpdatedEvent(2, {
+      status: 'loading',
+      url: undefined,
+      title: undefined,
+      pinned: undefined,
+    }))))
       .once()
   })
 

--- a/lib/api/test/spec/tabs/safari.ts
+++ b/lib/api/test/spec/tabs/safari.ts
@@ -154,7 +154,7 @@ export default ({ safari }) => {
     expect((target as any).eid).to.equal(1)
   })
 
-  it('registers tab updated event', () => {
+  it('registers tab updated event for navigate event', () => {
     tabs.registerEvents(instance(dispatcher))
     Date.now = sinon.stub().returns(2)
 
@@ -163,7 +163,51 @@ export default ({ safari }) => {
 
     target.trigger('navigate')
 
-    verify(dispatcher.fire(deepEqual(new TabUpdatedEvent(target.eid))))
+    verify(dispatcher.fire(deepEqual(new TabUpdatedEvent(target.eid, {
+      status: 'complete',
+    }))))
+      .once()
+
+    expect((target as any).eid).to.equal(2)
+  })
+
+  it('registers tab updated event for beforeNavigate event with same url', () => {
+    tabs.registerEvents(instance(dispatcher))
+    Date.now = sinon.stub().returns(2)
+
+    const target = new SafariTabMock('http://test.com')
+    safari.application.trigger('open', { target })
+
+    target.trigger('beforeNavigate', {
+      url: 'test',
+      target: { url: 'test' },
+    })
+
+    verify(dispatcher.fire(deepEqual(new TabUpdatedEvent(target.eid, {
+      status: 'loading',
+      url: undefined,
+    }))))
+      .once()
+
+    expect((target as any).eid).to.equal(2)
+  })
+
+  it('registers tab updated event for beforeNavigate event with different url', () => {
+    tabs.registerEvents(instance(dispatcher))
+    Date.now = sinon.stub().returns(2)
+
+    const target = new SafariTabMock('http://test.com')
+    safari.application.trigger('open', { target })
+
+    target.trigger('beforeNavigate', {
+      url: 'test',
+      target: { url: 'test2' },
+    })
+
+    verify(dispatcher.fire(deepEqual(new TabUpdatedEvent(target.eid, {
+      status: 'loading',
+      url: 'test',
+    }))))
       .once()
 
     expect((target as any).eid).to.equal(2)


### PR DESCRIPTION
**References issue**
#123

**Describe the pull request**
Added change info for tab events. Instead of creating a new interface I have reused the `chrome.tabs.TabChangeInfo` from chrome types.
Also removed misleading `webRequest` safari event.

**New features or API**
`TabUpdatedEvent` now has `changeInfo` property that is of type `chrome.tabs.TabChangeInfo`.

**Additional context**
In Safari, `TabUpdatedEvent` only triggers if `status` or `url` is changed. Other tab changes are ignored.
