### PR TITLE
Update Browsers Support (Microsoft Edge Chromium)

### DIFF
--- a/lib/api/src/browserAction/BrowserActionProvider.ts
+++ b/lib/api/src/browserAction/BrowserActionProvider.ts
@@ -21,7 +21,7 @@ export class BrowserActionProvider extends Provider {
    */
   public boot () : void {
     this.container.bind<BrowserAction>(ChromeBrowserAction).to(BrowserAction).for(Browser.CHROME)
-    // this.container.bind<BrowserAction>(ChromeBrowserAction).to(BrowserAction).for(Browser.EDGE)
+    this.container.bind<BrowserAction>(ChromeBrowserAction).to(BrowserAction).for(Browser.EDGE)
     this.container.bind<BrowserAction>(ExtensionsBrowserAction).to(BrowserAction).for(Browser.EXTENSIONS)
     this.container.bind<BrowserAction>(SafariBrowserAction).to(BrowserAction).for(Browser.SAFARI)
   }

--- a/lib/api/src/browserAction/BrowserActionProvider.ts
+++ b/lib/api/src/browserAction/BrowserActionProvider.ts
@@ -21,6 +21,7 @@ export class BrowserActionProvider extends Provider {
    */
   public boot () : void {
     this.container.bind<BrowserAction>(ChromeBrowserAction).to(BrowserAction).for(Browser.CHROME)
+    // this.container.bind<BrowserAction>(ChromeBrowserAction).to(BrowserAction).for(Browser.EDGE)
     this.container.bind<BrowserAction>(ExtensionsBrowserAction).to(BrowserAction).for(Browser.EXTENSIONS)
     this.container.bind<BrowserAction>(SafariBrowserAction).to(BrowserAction).for(Browser.SAFARI)
   }

--- a/lib/api/src/contextMenus/ContextMenusProvider.ts
+++ b/lib/api/src/contextMenus/ContextMenusProvider.ts
@@ -20,7 +20,7 @@ export class ContextMenusProvider extends Provider {
    */
   public boot () : void {
     this.container.bind(ChromeContextMenus).to(ContextMenus).for(Browser.CHROME)
-    // this.container.bind(ChromeContextMenus).to(ContextMenus).for(Browser.EDGE)
+    this.container.bind(ChromeContextMenus).to(ContextMenus).for(Browser.EDGE)
     this.container.bind(ExtensionsContextMenus).to(ContextMenus).for(Browser.EXTENSIONS)
     this.container.bind(SafariContextMenus).to(ContextMenus).for(Browser.SAFARI)
 

--- a/lib/api/src/contextMenus/ContextMenusProvider.ts
+++ b/lib/api/src/contextMenus/ContextMenusProvider.ts
@@ -20,6 +20,7 @@ export class ContextMenusProvider extends Provider {
    */
   public boot () : void {
     this.container.bind(ChromeContextMenus).to(ContextMenus).for(Browser.CHROME)
+    // this.container.bind(ChromeContextMenus).to(ContextMenus).for(Browser.EDGE)
     this.container.bind(ExtensionsContextMenus).to(ContextMenus).for(Browser.EXTENSIONS)
     this.container.bind(SafariContextMenus).to(ContextMenus).for(Browser.SAFARI)
 

--- a/lib/api/src/cookies/CookiesProvider.ts
+++ b/lib/api/src/cookies/CookiesProvider.ts
@@ -22,7 +22,7 @@ export class CookiesProvider extends Provider {
    */
   public boot () : void {
     this.container.bind<Cookies>(ChromeCookies).to(Cookies).for(Browser.CHROME)
-    // this.container.bind<Cookies>(ChromeCookies).to(Cookies).for(Browser.EDGE)
+    this.container.bind<Cookies>(ChromeCookies).to(Cookies).for(Browser.EDGE)
     this.container.bind<Cookies>(ExtensionsCookies).to(Cookies).for(Browser.EXTENSIONS)
     this.container.bind<Cookies>(SafariCookies).to(Cookies).for(Browser.SAFARI)
 

--- a/lib/api/src/cookies/CookiesProvider.ts
+++ b/lib/api/src/cookies/CookiesProvider.ts
@@ -22,6 +22,7 @@ export class CookiesProvider extends Provider {
    */
   public boot () : void {
     this.container.bind<Cookies>(ChromeCookies).to(Cookies).for(Browser.CHROME)
+    // this.container.bind<Cookies>(ChromeCookies).to(Cookies).for(Browser.EDGE)
     this.container.bind<Cookies>(ExtensionsCookies).to(Cookies).for(Browser.EXTENSIONS)
     this.container.bind<Cookies>(SafariCookies).to(Cookies).for(Browser.SAFARI)
 

--- a/lib/api/src/extension/ExtensionProvider.ts
+++ b/lib/api/src/extension/ExtensionProvider.ts
@@ -12,7 +12,7 @@ export class ExtensionProvider extends Provider {
    */
   public boot () : void {
     this.container.bind<Extension>(ChromeExtension).to(Extension).for(Browser.CHROME)
-    // this.container.bind<Extension>(ChromeExtension).to(Extension).for(Browser.EDGE)
+    this.container.bind<Extension>(ChromeExtension).to(Extension).for(Browser.EDGE)
     this.container.bind<Extension>(ExtensionsExtension).to(Extension).for(Browser.EXTENSIONS)
     this.container.bind<Extension>(SafariExtension).to(Extension).for(Browser.SAFARI)
   }

--- a/lib/api/src/extension/ExtensionProvider.ts
+++ b/lib/api/src/extension/ExtensionProvider.ts
@@ -12,6 +12,7 @@ export class ExtensionProvider extends Provider {
    */
   public boot () : void {
     this.container.bind<Extension>(ChromeExtension).to(Extension).for(Browser.CHROME)
+    // this.container.bind<Extension>(ChromeExtension).to(Extension).for(Browser.EDGE)
     this.container.bind<Extension>(ExtensionsExtension).to(Extension).for(Browser.EXTENSIONS)
     this.container.bind<Extension>(SafariExtension).to(Extension).for(Browser.SAFARI)
   }

--- a/lib/api/src/messaging/MessagingProvider.ts
+++ b/lib/api/src/messaging/MessagingProvider.ts
@@ -12,6 +12,7 @@ export class MessagingProvider extends Provider {
    */
   public boot () : void {
     this.container.bind<Messaging>(ChromeMessaging).to(Messaging).for(Browser.CHROME).asSingleton()
+    // this.container.bind<Messaging>(ChromeMessaging).to(Messaging).for(Browser.EDGE).asSingleton()
     this.container.bind<Messaging>(ExtensionsMessaging).to(Messaging).for(Browser.EXTENSIONS).asSingleton()
     this.container.bind<Messaging>(SafariMessaging).to(Messaging).for(Browser.SAFARI).asSingleton()
   }

--- a/lib/api/src/messaging/MessagingProvider.ts
+++ b/lib/api/src/messaging/MessagingProvider.ts
@@ -12,7 +12,7 @@ export class MessagingProvider extends Provider {
    */
   public boot () : void {
     this.container.bind<Messaging>(ChromeMessaging).to(Messaging).for(Browser.CHROME).asSingleton()
-    // this.container.bind<Messaging>(ChromeMessaging).to(Messaging).for(Browser.EDGE).asSingleton()
+    this.container.bind<Messaging>(ChromeMessaging).to(Messaging).for(Browser.EDGE).asSingleton()
     this.container.bind<Messaging>(ExtensionsMessaging).to(Messaging).for(Browser.EXTENSIONS).asSingleton()
     this.container.bind<Messaging>(SafariMessaging).to(Messaging).for(Browser.SAFARI).asSingleton()
   }

--- a/lib/api/src/permissions/PermissionManagerProvider.ts
+++ b/lib/api/src/permissions/PermissionManagerProvider.ts
@@ -21,6 +21,7 @@ export class PermissionManagerProvider extends Provider {
    */
   public boot () : void {
     this.container.bind<PermissionManager>(ChromePermissionManager).to(PermissionManager).for(Browser.CHROME)
+    // this.container.bind<PermissionManager>(ChromePermissionManager).to(PermissionManager).for(Browser.EDGE)
     this.container.bind<PermissionManager>(ExtensionsPermissionManager).to(PermissionManager).for(Browser.EXTENSIONS)
     this.container.bind<PermissionManager>(SafariPermissionManager).to(PermissionManager).for(Browser.SAFARI)
   }

--- a/lib/api/src/permissions/PermissionManagerProvider.ts
+++ b/lib/api/src/permissions/PermissionManagerProvider.ts
@@ -21,7 +21,7 @@ export class PermissionManagerProvider extends Provider {
    */
   public boot () : void {
     this.container.bind<PermissionManager>(ChromePermissionManager).to(PermissionManager).for(Browser.CHROME)
-    // this.container.bind<PermissionManager>(ChromePermissionManager).to(PermissionManager).for(Browser.EDGE)
+    this.container.bind<PermissionManager>(ChromePermissionManager).to(PermissionManager).for(Browser.EDGE)
     this.container.bind<PermissionManager>(ExtensionsPermissionManager).to(PermissionManager).for(Browser.EXTENSIONS)
     this.container.bind<PermissionManager>(SafariPermissionManager).to(PermissionManager).for(Browser.SAFARI)
   }

--- a/lib/api/src/runtime/RuntimeProvider.ts
+++ b/lib/api/src/runtime/RuntimeProvider.ts
@@ -22,6 +22,7 @@ export class RuntimeProvider extends Provider {
    */
   public boot () : void {
     this.container.bind<Runtime>(ChromeRuntime).to(Runtime).for(Browser.CHROME)
+    // this.container.bind<Runtime>(ChromeRuntime).to(Runtime).for(Browser.EDGE)
     this.container.bind<Runtime>(ExtensionsRuntime).to(Runtime).for(Browser.EXTENSIONS)
     this.container.bind<Runtime>(SafariRuntime).to(Runtime).for(Browser.SAFARI)
 

--- a/lib/api/src/runtime/RuntimeProvider.ts
+++ b/lib/api/src/runtime/RuntimeProvider.ts
@@ -22,7 +22,7 @@ export class RuntimeProvider extends Provider {
    */
   public boot () : void {
     this.container.bind<Runtime>(ChromeRuntime).to(Runtime).for(Browser.CHROME)
-    // this.container.bind<Runtime>(ChromeRuntime).to(Runtime).for(Browser.EDGE)
+    this.container.bind<Runtime>(ChromeRuntime).to(Runtime).for(Browser.EDGE)
     this.container.bind<Runtime>(ExtensionsRuntime).to(Runtime).for(Browser.EXTENSIONS)
     this.container.bind<Runtime>(SafariRuntime).to(Runtime).for(Browser.SAFARI)
 

--- a/lib/api/src/storage/StorageProvider.ts
+++ b/lib/api/src/storage/StorageProvider.ts
@@ -30,6 +30,11 @@ export class StorageProvider extends Provider {
     this.container.bind<Storage>(ChromeSyncStorage)
       .to(Storage).for(Browser.CHROME).tag('type', StorageType.SYNC)
 
+    // this.container.bind<Storage>(ChromeLocalStorage)
+    //   .to(Storage).for(Browser.EDGE).tag('type', StorageType.LOCAL)
+    // this.container.bind<Storage>(ChromeSyncStorage)
+    //   .to(Storage).for(Browser.EDGE).tag('type', StorageType.SYNC)
+
     this.container.bind<Storage>(ExtensionsLocalStorage)
       .to(Storage).for(Browser.EXTENSIONS).tag('type', StorageType.LOCAL)
     this.container.bind<Storage>(ExtensionsSyncStorage)

--- a/lib/api/src/storage/StorageProvider.ts
+++ b/lib/api/src/storage/StorageProvider.ts
@@ -30,10 +30,10 @@ export class StorageProvider extends Provider {
     this.container.bind<Storage>(ChromeSyncStorage)
       .to(Storage).for(Browser.CHROME).tag('type', StorageType.SYNC)
 
-    // this.container.bind<Storage>(ChromeLocalStorage)
-    //   .to(Storage).for(Browser.EDGE).tag('type', StorageType.LOCAL)
-    // this.container.bind<Storage>(ChromeSyncStorage)
-    //   .to(Storage).for(Browser.EDGE).tag('type', StorageType.SYNC)
+    this.container.bind<Storage>(ChromeLocalStorage)
+      .to(Storage).for(Browser.EDGE).tag('type', StorageType.LOCAL)
+    this.container.bind<Storage>(ChromeSyncStorage)
+      .to(Storage).for(Browser.EDGE).tag('type', StorageType.SYNC)
 
     this.container.bind<Storage>(ExtensionsLocalStorage)
       .to(Storage).for(Browser.EXTENSIONS).tag('type', StorageType.LOCAL)

--- a/lib/api/src/tabs/TabsProvider.ts
+++ b/lib/api/src/tabs/TabsProvider.ts
@@ -21,6 +21,7 @@ export class TabsProvider extends Provider {
    */
   public boot () : void {
     this.container.bind<Tabs>(ChromeTabs).to(Tabs).for(Browser.CHROME)
+    // this.container.bind<Tabs>(ChromeTabs).to(Tabs).for(Browser.EDGE)
     this.container.bind<Tabs>(ExtensionsTabs).to(Tabs).for(Browser.EXTENSIONS)
     this.container.bind<Tabs>(SafariTabs).to(Tabs).for(Browser.SAFARI)
   }

--- a/lib/api/src/tabs/TabsProvider.ts
+++ b/lib/api/src/tabs/TabsProvider.ts
@@ -21,7 +21,7 @@ export class TabsProvider extends Provider {
    */
   public boot () : void {
     this.container.bind<Tabs>(ChromeTabs).to(Tabs).for(Browser.CHROME)
-    // this.container.bind<Tabs>(ChromeTabs).to(Tabs).for(Browser.EDGE)
+    this.container.bind<Tabs>(ChromeTabs).to(Tabs).for(Browser.EDGE)
     this.container.bind<Tabs>(ExtensionsTabs).to(Tabs).for(Browser.EXTENSIONS)
     this.container.bind<Tabs>(SafariTabs).to(Tabs).for(Browser.SAFARI)
   }

--- a/lib/core/src/support/Browser.ts
+++ b/lib/core/src/support/Browser.ts
@@ -4,7 +4,9 @@
  */
 export enum Browser {
   CHROME = 'chrome',
+  EDGE = 'edge',
   EXTENSIONS = 'extensions',
+  OPERA = 'opera',
   SAFARI = 'safari',
   TESTING = 'testing',
 }

--- a/lib/core/src/support/Utils.ts
+++ b/lib/core/src/support/Utils.ts
@@ -12,20 +12,23 @@ export class Utils {
       return Browser.TESTING
     }
 
-    // Some checking logic for browsers.
-    const extensions: boolean = typeof (window as any).InstallTrigger !== 'undefined'
-      || (!(document as any).documentNode && (window as any).StyleMedia)
+    // Some checking logic for browsers; prioritise duck-typing over User-Agent string.
+    // Methods are borrowed from the following SO resource which is regularly updated:
+    // https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser#9851769
 
     const chrome: boolean = !!(window as any).chrome
       && (!!(window as any).chrome.webstore || !!(window as any).chrome.runtime)
 
-    const edge: boolean = chrome && (navigator.userAgent.indexOf("Edg") != -1)
+    const edge: boolean = chrome && (navigator.userAgent.indexOf('Edg') !== -1)
+
+    const extensions: boolean = typeof (window as any).InstallTrigger !== 'undefined'
+      || (!(document as any).documentNode && (window as any).StyleMedia)
 
     const opera: boolean = (!!(window as any).opr && !!(window as any).addons)
       || !!(window as any).opera || navigator.userAgent.indexOf(' OPR/') >= 0
 
+    // Currently we will not return `Browser.OPERA` but fall back to `.CHROME`
     return extensions ? Browser.EXTENSIONS
-      : opera ? Browser.OPERA
       : edge ? Browser.EDGE
       : chrome ? Browser.CHROME
       : Browser.SAFARI

--- a/lib/core/src/support/Utils.ts
+++ b/lib/core/src/support/Utils.ts
@@ -19,7 +19,14 @@ export class Utils {
     const chrome: boolean = !!(window as any).chrome
       && (!!(window as any).chrome.webstore || !!(window as any).chrome.runtime)
 
+    const edge: boolean = chrome && (navigator.userAgent.indexOf("Edg") != -1)
+
+    const opera: boolean = (!!(window as any).opr && !!(window as any).addons)
+      || !!(window as any).opera || navigator.userAgent.indexOf(' OPR/') >= 0
+
     return extensions ? Browser.EXTENSIONS
+      : opera ? Browser.OPERA
+      : edge ? Browser.EDGE
       : chrome ? Browser.CHROME
       : Browser.SAFARI
   }

--- a/lib/core/test/setup.ts
+++ b/lib/core/test/setup.ts
@@ -14,7 +14,12 @@ const window: any = {
 
 const document: any = {}
 
+const navigator: any = {
+  userAgent: ''
+}
+
 window.top = window
 
 ;(global as any).window = window
 ;(global as any).document = document
+;(global as any).navigator = navigator


### PR DESCRIPTION
Adding support for Microsoft Edge (Chromium) and Opera (Chromium) browsers in core utils.

Current Browser util service can distinguish Edge and Opera from Chrome but on detecting Edge or Opera the API wrapper 'Providers' bind on Chrome.

Opera will not recognise `chrome.storage.sync` but uses only `chrome.storage.local` so it may be desirable either not to accommodate Opera or to find a way to switch from `sync` to `local` if appropriate - see https://dev.opera.com/extensions/apis/ (certain `chrome.tabs` methods and events also are not supported but I believe this will not be an issue for exteranto).

Current Browser Util updated to check for Opera and Edge and determine in correct order respective to Google Chrome. Following the feature-checking pattern already used and as proposed here: https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser#9851769

UPDATE: Opera browser feature detection is included but disabled until further notice - current PR adds support for Edge only, Opera support to be introduced later following @bausano's suggested storage workaround - All test passing but no Edge specific tests added since we can rely on Chrome tests in short term...