### PR TITLE
Switch dependencies to peer

### DIFF
--- a/lib/api/package.json
+++ b/lib/api/package.json
@@ -31,9 +31,6 @@
   ],
   "repository": "github:exteranto/api",
   "license": "MIT",
-  "dependencies": {
-    "@exteranto/core": "^3.2.2"
-  },
   "devDependencies": {
     "@types/chai": "^4.2.11",
     "@types/chai-as-promised": "^7.1.2",
@@ -56,6 +53,9 @@
     "ttypescript": "^1.5.10",
     "typescript": "^3.9.2",
     "web-ext-types": "^3.2.1"
+  },
+  "peerDependencies": {
+    "@exteranto/core": "^3.2.2"
   },
   "nyc": {
     "extension": [

--- a/lib/utils/package.json
+++ b/lib/utils/package.json
@@ -31,8 +31,6 @@
   "repository": "github:exteranto/utils",
   "license": "MIT",
   "dependencies": {
-    "@exteranto/api": "^3.2.2",
-    "@exteranto/core": "^3.2.2",
     "md5-typescript": "^1.0.5"
   },
   "devDependencies": {
@@ -53,6 +51,10 @@
     "tslint": "^6.1.2",
     "ttypescript": "^1.5.10",
     "typescript": "^3.9.2"
+  },
+  "peerDependencies": {
+    "@exteranto/api": "^3.2.2",
+    "@exteranto/core": "^3.2.2"
   },
   "nyc": {
     "extension": [


### PR DESCRIPTION
Switch @externato dependencies to peer to avoid version conflicts when using them together
