### PR TITLE
Feature improve window load handling

### DIFF
--- a/lib/core/src/app/App.ts
+++ b/lib/core/src/app/App.ts
@@ -1,5 +1,5 @@
 import { Provider, Script, Utils } from '@internal/support'
-import { AppBootedEvent, WindowLoadedEvent } from './events'
+import { AppBootedEvent, WindowLoadedEvent, WindowContentEvent } from './events'
 import { Autowired, Container, Self, Class } from '@internal/ioc'
 import { Dispatcher, Event, ListenerBag } from '@internal/events'
 
@@ -43,7 +43,7 @@ export class App {
   public bootstrap () : void {
     this.registerBaseParams()
     this.registerParamBindings()
-    this.registerWindowLoadEvent()
+    this.registerWindowEvents()
     this.findProviders()
     this.bootProviders()
     this.registerProviders()
@@ -69,16 +69,20 @@ export class App {
   }
 
   /**
-   * Register the arbitrary window load event.
+   * Register the arbitrary window content / load events.
    */
-  private registerWindowLoadEvent () : void {
+  private registerWindowEvents () : void {
     if (document.readyState === 'complete') {
       return this.dispatcher.mail(new WindowLoadedEvent())
     }
 
+    window.addEventListener('DOMContentLoaded', () => {
+      this.dispatcher.mail(new WindowContentEvent())
+    }, { once: true })
+
     window.addEventListener('load', () => {
       this.dispatcher.mail(new WindowLoadedEvent())
-    })
+    }, { once: true })
   }
 
   /**

--- a/lib/core/src/app/App.ts
+++ b/lib/core/src/app/App.ts
@@ -1,7 +1,7 @@
 import { Provider, Script, Utils } from '@internal/support'
-import { AppBootedEvent, WindowLoadedEvent, WindowContentEvent } from './events'
 import { Autowired, Container, Self, Class } from '@internal/ioc'
 import { Dispatcher, Event, ListenerBag } from '@internal/events'
+import { AppBootedEvent, WindowLoadedEvent, WindowContentEvent } from './events'
 
 export class App {
 

--- a/lib/core/src/app/App.ts
+++ b/lib/core/src/app/App.ts
@@ -76,12 +76,16 @@ export class App {
       return this.dispatcher.mail(new WindowLoadedEvent())
     }
 
-    window.addEventListener('DOMContentLoaded', () => {
-      this.dispatcher.mail(new WindowContentEvent())
-    }, { once: true })
-
     window.addEventListener('load', () => {
       this.dispatcher.mail(new WindowLoadedEvent())
+    }, { once: true })
+
+    if (document.readyState === 'interactive') {
+      return this.dispatcher.mail(new WindowContentEvent())
+    }
+
+    window.addEventListener('DOMContentLoaded', () => {
+      this.dispatcher.mail(new WindowContentEvent())
     }, { once: true })
   }
 

--- a/lib/core/src/app/App.ts
+++ b/lib/core/src/app/App.ts
@@ -69,9 +69,10 @@ export class App {
   }
 
   /**
-   * Register the arbitrary window content / load events.
+   * Register the arbitrary window content/load events.
    */
   private registerWindowEvents () : void {
+    // Handy full window load state
     if (document.readyState === 'complete') {
       return this.dispatcher.mail(new WindowLoadedEvent())
     }
@@ -80,6 +81,7 @@ export class App {
       this.dispatcher.mail(new WindowLoadedEvent())
     }, { once: true })
 
+    // Handle window in interactive state
     if (document.readyState === 'interactive') {
       return this.dispatcher.mail(new WindowContentEvent())
     }

--- a/lib/core/src/app/events.ts
+++ b/lib/core/src/app/events.ts
@@ -1,6 +1,14 @@
 import { Event } from '@internal/events'
 
 /**
+ * The Window content event is fired after the native window.domcontentloaded
+ * event is triggered. This event has no payload.
+ */
+export class WindowContentEvent extends Event {
+  //
+}
+
+/**
  * The window loaded event is fired after the native window.load event is
  * triggered. This event has no payload.
  */

--- a/lib/core/test/spec/app/App.spec.ts
+++ b/lib/core/test/spec/app/App.spec.ts
@@ -129,6 +129,7 @@ describe('App', () => {
     ;(global as any).window.addEventListener = referenceStore
 
     verify(dispatcher.mail(deepEqual(new WindowContentEvent))).once()
+    verify(dispatcher.mail(deepEqual(new WindowLoadedEvent))).never()
   })
 
   it('does not fire the window content event if window is already loaded', () => {

--- a/lib/core/test/spec/app/App.spec.ts
+++ b/lib/core/test/spec/app/App.spec.ts
@@ -4,7 +4,7 @@ import { mock, instance, verify, deepEqual, when, anything } from 'ts-mockito'
 import { Container } from '@internal/ioc'
 import { Dispatcher, Event } from '@internal/events'
 import { Provider, Script } from '@internal/support'
-import { App, WindowLoadedEvent, AppBootedEvent } from '@internal/app'
+import { App, WindowContentEvent, WindowLoadedEvent, AppBootedEvent } from '@internal/app'
 
 describe('App', () => {
   let container: Container
@@ -79,6 +79,16 @@ describe('App', () => {
     verify(dispatcher.fire(deepEqual(new AppBootedEvent))).once()
   })
 
+  it('registers the window content event', () => {
+    const app: App = new App(Script.BACKGROUND, { providers: [] }, () => {})
+
+    ;(app as any).dispatcher = instance(dispatcher)
+
+    app.bootstrap()
+
+    verify(dispatcher.mail(deepEqual(new WindowContentEvent))).once()
+  })
+
   it('registers the window load event', () => {
     const app: App = new App(Script.BACKGROUND, { providers: [] }, () => {})
 
@@ -104,6 +114,41 @@ describe('App', () => {
 
     verify(dispatcher.mail(deepEqual(new WindowLoadedEvent))).once()
   })
+
+  it('fire the window content event if window is already interactive', () => {
+    const app: App = new App(Script.BACKGROUND, { providers: [] }, () => {})
+
+    ;(app as any).dispatcher = instance(dispatcher)
+
+    const referenceStore = (global as any).window.addEventListener
+    ;(global as any).window.addEventListener = () => {}
+    ;(global as any).document.readyState = 'interactive'
+
+    app.bootstrap()
+
+    ;(global as any).window.addEventListener = referenceStore
+
+    verify(dispatcher.mail(deepEqual(new WindowContentEvent))).once()
+  })
+
+  it('does not fire the window content event if window is already loaded', () => {
+    const app: App = new App(Script.BACKGROUND, { providers: [] }, () => {})
+
+    ;(app as any).dispatcher = instance(dispatcher)
+
+    const referenceStore = (global as any).window.addEventListener
+    ;(global as any).window.addEventListener = () => {}
+    ;(global as any).document.readyState = 'complete'
+
+    app.bootstrap()
+
+    ;(global as any).window.addEventListener = referenceStore
+
+    verify(dispatcher.mail(deepEqual(new WindowLoadedEvent))).once()
+    verify(dispatcher.mail(deepEqual(new WindowContentEvent))).never()
+
+  })
+
 
 })
 


### PR DESCRIPTION
We recently faced an issue with the `WindowLoad` event being triggered twice by an SPA which somehow dispatched native `window.onload` event twice. This is rare but possible and it causes issues in particular for how we inject data into the content page (e.g. custom scripts duplicated....). I have added a `{ once: true }` option to the registration of the event on native window load, which prevents this issue.

Further, we felt it may be useful to be able to trigger events/messages on the 'domcontentloaded' event as well as full page load - this will hopefully allow for increase in perceived performance in many circumstances (alternative would be to trigger many processes on the `AppBootedEvent` which we may still do although this could clearly lead to problems with message registration etc.
